### PR TITLE
feat: add clientes dialog

### DIFF
--- a/app/data/db.py
+++ b/app/data/db.py
@@ -75,3 +75,22 @@ def contar_reparaciones_pendientes() -> int:
     cur = _ensure_conn().cursor()
     cur.execute("SELECT COUNT(*) FROM reparaciones WHERE estado = 'Pendiente'")
     return cur.fetchone()[0]
+
+def listar_clientes():
+    cur = _ensure_conn().cursor()
+    cur.execute("SELECT id, nombre FROM clientes ORDER BY id")
+    return cur.fetchall()
+
+def add_cliente(nombre: str) -> int:
+    conn = _ensure_conn()
+    cur = conn.cursor()
+    cur.execute("INSERT INTO clientes (nombre) VALUES (?)", (nombre,))
+    conn.commit()
+    return cur.lastrowid
+
+def delete_cliente(cliente_id: int) -> bool:
+    conn = _ensure_conn()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM clientes WHERE id = ?", (cliente_id,))
+    conn.commit()
+    return cur.rowcount > 0

--- a/app/ui/clientes.ui
+++ b/app/ui/clientes.ui
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ClientesDialog</class>
+ <widget class="QDialog" name="ClientesDialog">
+  <property name="windowTitle">
+   <string>Clientes</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="lineEditNombre"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnAgregar">
+       <property name="text">
+        <string>Agregar</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="tableClientes">
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <column>
+      <property name="text">
+       <string>ID</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Nombre</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="btnEliminar">
+       <property name="text">
+        <string>Eliminar</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnCerrar">
+       <property name="text">
+        <string>Cerrar</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/app/ui/ui_clientes.py
+++ b/app/ui/ui_clientes.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'clientes.ui'
+##
+## Created by: Qt User Interface Compiler version 6.9.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QDialog, QHBoxLayout,
+    QHeaderView, QLineEdit, QPushButton, QSizePolicy,
+    QSpacerItem, QTableWidget, QTableWidgetItem, QVBoxLayout,
+    QWidget)
+
+class Ui_ClientesDialog(object):
+    def setupUi(self, ClientesDialog):
+        if not ClientesDialog.objectName():
+            ClientesDialog.setObjectName(u"ClientesDialog")
+        self.verticalLayout = QVBoxLayout(ClientesDialog)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.horizontalLayout = QHBoxLayout()
+        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.lineEditNombre = QLineEdit(ClientesDialog)
+        self.lineEditNombre.setObjectName(u"lineEditNombre")
+
+        self.horizontalLayout.addWidget(self.lineEditNombre)
+
+        self.btnAgregar = QPushButton(ClientesDialog)
+        self.btnAgregar.setObjectName(u"btnAgregar")
+
+        self.horizontalLayout.addWidget(self.btnAgregar)
+
+
+        self.verticalLayout.addLayout(self.horizontalLayout)
+
+        self.tableClientes = QTableWidget(ClientesDialog)
+        if (self.tableClientes.columnCount() < 2):
+            self.tableClientes.setColumnCount(2)
+        __qtablewidgetitem = QTableWidgetItem()
+        self.tableClientes.setHorizontalHeaderItem(0, __qtablewidgetitem)
+        __qtablewidgetitem1 = QTableWidgetItem()
+        self.tableClientes.setHorizontalHeaderItem(1, __qtablewidgetitem1)
+        self.tableClientes.setObjectName(u"tableClientes")
+        self.tableClientes.setColumnCount(2)
+        self.tableClientes.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.tableClientes.setEditTriggers(QAbstractItemView.NoEditTriggers)
+
+        self.verticalLayout.addWidget(self.tableClientes)
+
+        self.horizontalLayout_2 = QHBoxLayout()
+        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.btnEliminar = QPushButton(ClientesDialog)
+        self.btnEliminar.setObjectName(u"btnEliminar")
+
+        self.horizontalLayout_2.addWidget(self.btnEliminar)
+
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.horizontalLayout_2.addItem(self.horizontalSpacer)
+
+        self.btnCerrar = QPushButton(ClientesDialog)
+        self.btnCerrar.setObjectName(u"btnCerrar")
+
+        self.horizontalLayout_2.addWidget(self.btnCerrar)
+
+
+        self.verticalLayout.addLayout(self.horizontalLayout_2)
+
+
+        self.retranslateUi(ClientesDialog)
+
+        QMetaObject.connectSlotsByName(ClientesDialog)
+    # setupUi
+
+    def retranslateUi(self, ClientesDialog):
+        ClientesDialog.setWindowTitle(QCoreApplication.translate("ClientesDialog", u"Clientes", None))
+        self.btnAgregar.setText(QCoreApplication.translate("ClientesDialog", u"Agregar", None))
+        ___qtablewidgetitem = self.tableClientes.horizontalHeaderItem(0)
+        ___qtablewidgetitem.setText(QCoreApplication.translate("ClientesDialog", u"ID", None));
+        ___qtablewidgetitem1 = self.tableClientes.horizontalHeaderItem(1)
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("ClientesDialog", u"Nombre", None));
+        self.btnEliminar.setText(QCoreApplication.translate("ClientesDialog", u"Eliminar", None))
+        self.btnCerrar.setText(QCoreApplication.translate("ClientesDialog", u"Cerrar", None))
+    # retranslateUi
+

--- a/app/views/clientes_dialog.py
+++ b/app/views/clientes_dialog.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from PySide6.QtWidgets import QDialog, QMessageBox, QTableWidgetItem
+from app.ui.ui_clientes import Ui_ClientesDialog
+from app.data import db
+
+
+class ClientesDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.ui = Ui_ClientesDialog()
+        self.ui.setupUi(self)
+
+        self.ui.btnAgregar.clicked.connect(self.agregar)
+        self.ui.btnEliminar.clicked.connect(self.eliminar)
+        self.ui.btnCerrar.clicked.connect(self.close)
+
+        self._load_clientes()
+
+    def _load_clientes(self):
+        self.ui.tableClientes.setRowCount(0)
+        for row, (cid, nombre) in enumerate(db.listar_clientes()):
+            self.ui.tableClientes.insertRow(row)
+            self.ui.tableClientes.setItem(row, 0, QTableWidgetItem(str(cid)))
+            self.ui.tableClientes.setItem(row, 1, QTableWidgetItem(nombre))
+        self.ui.tableClientes.resizeColumnsToContents()
+
+    def agregar(self):
+        nombre = self.ui.lineEditNombre.text().strip()
+        if not nombre:
+            QMessageBox.warning(self, "Validación", "El nombre no puede estar vacío.")
+            return
+        db.add_cliente(nombre)
+        self.ui.lineEditNombre.clear()
+        self._load_clientes()
+
+    def eliminar(self):
+        row = self.ui.tableClientes.currentRow()
+        if row < 0:
+            QMessageBox.warning(self, "Eliminar", "Seleccione un cliente.")
+            return
+        id_item = self.ui.tableClientes.item(row, 0)
+        if not id_item:
+            return
+        cid = int(id_item.text())
+        if QMessageBox.question(self, "Confirmar", "¿Eliminar cliente seleccionado?") == QMessageBox.Yes:
+            db.delete_cliente(cid)
+            self._load_clientes()

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -2,6 +2,7 @@
 from PySide6.QtWidgets import QMainWindow, QMessageBox
 from app.ui.ui_main_window import Ui_MainWindow
 from app.data import db
+from app.views.clientes_dialog import ClientesDialog
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -11,12 +12,17 @@ class MainWindow(QMainWindow):
 
         # Conexión de acciones del menú
         self.ui.actionSalir.triggered.connect(self.close)
-        self.ui.actionClientes.triggered.connect(lambda: self._no_impl("Clientes"))
+        self.ui.actionClientes.triggered.connect(self._open_clientes)
         self.ui.actionDispositivos.triggered.connect(lambda: self._no_impl("Dispositivos"))
         self.ui.actionInventario.triggered.connect(lambda: self._no_impl("Inventario"))
         self.ui.actionReparaciones.triggered.connect(lambda: self._no_impl("Reparaciones"))
 
         # Resumen inicial
+        self._refresh_summary()
+
+    def _open_clientes(self):
+        dlg = ClientesDialog(self)
+        dlg.exec()
         self._refresh_summary()
 
     def _refresh_summary(self):


### PR DESCRIPTION
## Summary
- add QDialog UI for managing clients
- implement ClientesDialog with add/remove and table refresh
- hook Clientes action in main window menu and expose DB helpers

## Testing
- `pip install -r requirements.txt`
- `pyside6-uic app/ui/main_window.ui -o app/ui/ui_main_window.py`
- `pyside6-uic app/ui/clientes.ui -o app/ui/ui_clientes.py`
- `python main.py` *(fails: ImportError: libGL.so.1)*


------
https://chatgpt.com/codex/tasks/task_e_689cd80edfb8832bac5add269082b0ed