### PR TITLE
feat: add inventory management dialog

### DIFF
--- a/app/data/db.py
+++ b/app/data/db.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sqlite3
 import os
-from typing import Optional
+from typing import Optional, List, Tuple
 
 DB_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "inventario_app.db")
 _conn: Optional[sqlite3.Connection] = None
@@ -92,5 +92,60 @@ def delete_cliente(cliente_id: int) -> bool:
     conn = _ensure_conn()
     cur = conn.cursor()
     cur.execute("DELETE FROM clientes WHERE id = ?", (cliente_id,))
+    conn.commit()
+    return cur.rowcount > 0
+
+
+# --- Inventario ---
+
+def get_products() -> List[Tuple[int, str, int]]:
+    cur = _ensure_conn().cursor()
+    cur.execute("SELECT id, nombre, cantidad FROM inventario ORDER BY id")
+    return cur.fetchall()
+
+
+def find_product_by_name(nombre: str) -> Optional[int]:
+    cur = _ensure_conn().cursor()
+    cur.execute("SELECT id FROM inventario WHERE nombre = ?", (nombre,))
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def add_product(nombre: str, cantidad: int) -> Optional[int]:
+    if find_product_by_name(nombre) is not None:
+        return None
+    conn = _ensure_conn()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO inventario (nombre, cantidad) VALUES (?, ?)",
+        (nombre, cantidad),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def update_product(product_id: int, *, name: Optional[str] = None, quantity: Optional[int] = None) -> bool:
+    if name is None and quantity is None:
+        return False
+    fields = []
+    params = []
+    if name is not None:
+        fields.append("nombre = ?")
+        params.append(name)
+    if quantity is not None:
+        fields.append("cantidad = ?")
+        params.append(quantity)
+    params.append(product_id)
+    conn = _ensure_conn()
+    cur = conn.cursor()
+    cur.execute(f"UPDATE inventario SET {', '.join(fields)} WHERE id = ?", params)
+    conn.commit()
+    return cur.rowcount > 0
+
+
+def delete_product(product_id: int) -> bool:
+    conn = _ensure_conn()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM inventario WHERE id = ?", (product_id,))
     conn.commit()
     return cur.rowcount > 0

--- a/app/ui/inventario.ui
+++ b/app/ui/inventario.ui
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>InventarioDialog</class>
+ <widget class="QDialog" name="InventarioDialog">
+  <property name="windowTitle">
+   <string>Inventario</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="layoutInputs">
+     <item>
+      <widget class="QLineEdit" name="lineEditNombre"/>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinCantidad">
+       <property name="minimum">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnAgregar">
+       <property name="text">
+        <string>Agregar</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="tableProductos">
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <column>
+      <property name="text">
+       <string>Nombre</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Cantidad</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="layoutButtons">
+     <item>
+      <widget class="QPushButton" name="btnEliminar">
+       <property name="text">
+        <string>Eliminar</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnCerrar">
+       <property name="text">
+        <string>Cerrar</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/app/ui/ui_inventario.py
+++ b/app/ui/ui_inventario.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'inventario.ui'
+##
+## Created by: Qt User Interface Compiler version 6.9.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QDialog, QHBoxLayout,
+    QHeaderView, QLineEdit, QPushButton, QSizePolicy,
+    QSpacerItem, QSpinBox, QTableWidget, QTableWidgetItem,
+    QVBoxLayout, QWidget)
+
+class Ui_InventarioDialog(object):
+    def setupUi(self, InventarioDialog):
+        if not InventarioDialog.objectName():
+            InventarioDialog.setObjectName(u"InventarioDialog")
+        self.verticalLayout = QVBoxLayout(InventarioDialog)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.layoutInputs = QHBoxLayout()
+        self.layoutInputs.setObjectName(u"layoutInputs")
+        self.lineEditNombre = QLineEdit(InventarioDialog)
+        self.lineEditNombre.setObjectName(u"lineEditNombre")
+
+        self.layoutInputs.addWidget(self.lineEditNombre)
+
+        self.spinCantidad = QSpinBox(InventarioDialog)
+        self.spinCantidad.setObjectName(u"spinCantidad")
+        self.spinCantidad.setMinimum(0)
+
+        self.layoutInputs.addWidget(self.spinCantidad)
+
+        self.btnAgregar = QPushButton(InventarioDialog)
+        self.btnAgregar.setObjectName(u"btnAgregar")
+
+        self.layoutInputs.addWidget(self.btnAgregar)
+
+
+        self.verticalLayout.addLayout(self.layoutInputs)
+
+        self.tableProductos = QTableWidget(InventarioDialog)
+        if (self.tableProductos.columnCount() < 2):
+            self.tableProductos.setColumnCount(2)
+        __qtablewidgetitem = QTableWidgetItem()
+        self.tableProductos.setHorizontalHeaderItem(0, __qtablewidgetitem)
+        __qtablewidgetitem1 = QTableWidgetItem()
+        self.tableProductos.setHorizontalHeaderItem(1, __qtablewidgetitem1)
+        self.tableProductos.setObjectName(u"tableProductos")
+        self.tableProductos.setColumnCount(2)
+        self.tableProductos.setSelectionBehavior(QAbstractItemView.SelectRows)
+
+        self.verticalLayout.addWidget(self.tableProductos)
+
+        self.layoutButtons = QHBoxLayout()
+        self.layoutButtons.setObjectName(u"layoutButtons")
+        self.btnEliminar = QPushButton(InventarioDialog)
+        self.btnEliminar.setObjectName(u"btnEliminar")
+
+        self.layoutButtons.addWidget(self.btnEliminar)
+
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.layoutButtons.addItem(self.horizontalSpacer)
+
+        self.btnCerrar = QPushButton(InventarioDialog)
+        self.btnCerrar.setObjectName(u"btnCerrar")
+
+        self.layoutButtons.addWidget(self.btnCerrar)
+
+
+        self.verticalLayout.addLayout(self.layoutButtons)
+
+
+        self.retranslateUi(InventarioDialog)
+
+        QMetaObject.connectSlotsByName(InventarioDialog)
+    # setupUi
+
+    def retranslateUi(self, InventarioDialog):
+        InventarioDialog.setWindowTitle(QCoreApplication.translate("InventarioDialog", u"Inventario", None))
+        self.btnAgregar.setText(QCoreApplication.translate("InventarioDialog", u"Agregar", None))
+        ___qtablewidgetitem = self.tableProductos.horizontalHeaderItem(0)
+        ___qtablewidgetitem.setText(QCoreApplication.translate("InventarioDialog", u"Nombre", None));
+        ___qtablewidgetitem1 = self.tableProductos.horizontalHeaderItem(1)
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("InventarioDialog", u"Cantidad", None));
+        self.btnEliminar.setText(QCoreApplication.translate("InventarioDialog", u"Eliminar", None))
+        self.btnCerrar.setText(QCoreApplication.translate("InventarioDialog", u"Cerrar", None))
+    # retranslateUi
+

--- a/app/views/inventario_dialog.py
+++ b/app/views/inventario_dialog.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from PySide6.QtWidgets import QDialog, QMessageBox, QTableWidgetItem
+from PySide6.QtCore import Qt
+
+from app.ui.ui_inventario import Ui_InventarioDialog
+from app.data import db
+
+
+class InventarioDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.ui = Ui_InventarioDialog()
+        self.ui.setupUi(self)
+
+        self._updating = False
+
+        self.ui.btnAgregar.clicked.connect(self.agregar)
+        self.ui.btnEliminar.clicked.connect(self.eliminar)
+        self.ui.btnCerrar.clicked.connect(self.close)
+        self.ui.tableProductos.itemChanged.connect(self._item_changed)
+
+        self._load_products()
+
+    def _load_products(self):
+        self._updating = True
+        table = self.ui.tableProductos
+        table.setRowCount(0)
+        for row, (pid, nombre, cantidad) in enumerate(db.get_products()):
+            table.insertRow(row)
+            name_item = QTableWidgetItem(nombre)
+            name_item.setData(Qt.UserRole, pid)
+            name_item.setFlags(name_item.flags() & ~Qt.ItemIsEditable)
+            qty_item = QTableWidgetItem(str(cantidad))
+            table.setItem(row, 0, name_item)
+            table.setItem(row, 1, qty_item)
+        table.resizeColumnsToContents()
+        self._updating = False
+
+    def agregar(self):
+        nombre = self.ui.lineEditNombre.text().strip()
+        cantidad = self.ui.spinCantidad.value()
+        if not nombre:
+            QMessageBox.warning(self, "Validación", "El nombre no puede estar vacío.")
+            return
+        if db.add_product(nombre, cantidad) is None:
+            QMessageBox.warning(self, "Duplicado", "Ya existe un producto con ese nombre.")
+            return
+        self.ui.lineEditNombre.clear()
+        self.ui.spinCantidad.setValue(0)
+        self._load_products()
+
+    def _item_changed(self, item):
+        if self._updating or item.column() != 1:
+            return
+        row = item.row()
+        name_item = self.ui.tableProductos.item(row, 0)
+        pid = name_item.data(Qt.UserRole)
+        try:
+            cantidad = int(item.text())
+            if cantidad < 0:
+                raise ValueError
+        except ValueError:
+            QMessageBox.warning(self, "Validación", "Cantidad inválida.")
+            self._load_products()
+            return
+        db.update_product(pid, quantity=cantidad)
+
+    def eliminar(self):
+        row = self.ui.tableProductos.currentRow()
+        if row < 0:
+            QMessageBox.warning(self, "Eliminar", "Seleccione un producto.")
+            return
+        name_item = self.ui.tableProductos.item(row, 0)
+        pid = name_item.data(Qt.UserRole)
+        if QMessageBox.question(self, "Confirmar", "¿Eliminar producto seleccionado?") == QMessageBox.Yes:
+            db.delete_product(pid)
+            self._load_products()

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -3,6 +3,7 @@ from PySide6.QtWidgets import QMainWindow, QMessageBox
 from app.ui.ui_main_window import Ui_MainWindow
 from app.data import db
 from app.views.clientes_dialog import ClientesDialog
+from app.views.inventario_dialog import InventarioDialog
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -14,7 +15,7 @@ class MainWindow(QMainWindow):
         self.ui.actionSalir.triggered.connect(self.close)
         self.ui.actionClientes.triggered.connect(self._open_clientes)
         self.ui.actionDispositivos.triggered.connect(lambda: self._no_impl("Dispositivos"))
-        self.ui.actionInventario.triggered.connect(lambda: self._no_impl("Inventario"))
+        self.ui.actionInventario.triggered.connect(self._open_inventario)
         self.ui.actionReparaciones.triggered.connect(lambda: self._no_impl("Reparaciones"))
 
         # Resumen inicial
@@ -22,6 +23,11 @@ class MainWindow(QMainWindow):
 
     def _open_clientes(self):
         dlg = ClientesDialog(self)
+        dlg.exec()
+        self._refresh_summary()
+
+    def _open_inventario(self):
+        dlg = InventarioDialog(self)
         dlg.exec()
         self._refresh_summary()
 


### PR DESCRIPTION
## Summary
- add SQLite helpers and CRUD dialog for managing inventory products
- wire new inventory dialog into main window menu
- generate inventory UI forms

## Testing
- `pip install -r requirements.txt`
- `pyside6-uic app/ui/main_window.ui -o app/ui/ui_main_window.py`
- `pyside6-uic app/ui/inventario.ui -o app/ui/ui_inventario.py`
- `QT_QPA_PLATFORM=offscreen python main.py`


------
https://chatgpt.com/codex/tasks/task_e_689cdee4e298832bb3eb9a89597c883b