### PR TITLE
feat: add reparaciones dialog

### DIFF
--- a/app/ui/reparaciones.ui
+++ b/app/ui/reparaciones.ui
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ReparacionesDialog</class>
+ <widget class="QDialog" name="ReparacionesDialog">
+  <property name="windowTitle">
+   <string>Nueva Reparación</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelCliente">
+       <property name="text">
+        <string>Cliente</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="lineEditCliente"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelMarca">
+       <property name="text">
+        <string>Marca</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lineEditMarca"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelModelo">
+       <property name="text">
+        <string>Modelo</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="lineEditModelo"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelDescripcion">
+       <property name="text">
+        <string>Descripción</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QPlainTextEdit" name="plainTextDescripcion"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelEstado">
+       <property name="text">
+        <string>Estado</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="comboEstado">
+       <item>
+        <property name="text">
+         <string>Pendiente</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Finalizada</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelCosto">
+       <property name="text">
+        <string>Costo</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLineEdit" name="inputCosto">
+       <property name="placeholderText">
+        <string>0.00</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonsLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnGuardar">
+       <property name="text">
+        <string>Guardar</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnCancelar">
+       <property name="text">
+        <string>Cancelar</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/app/ui/ui_reparaciones.py
+++ b/app/ui/ui_reparaciones.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'reparaciones.ui'
+##
+## Created by: Qt User Interface Compiler version 6.9.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QComboBox, QDialog, QFormLayout,
+    QHBoxLayout, QLabel, QLineEdit, QPlainTextEdit,
+    QPushButton, QSizePolicy, QSpacerItem, QVBoxLayout,
+    QWidget)
+
+class Ui_ReparacionesDialog(object):
+    def setupUi(self, ReparacionesDialog):
+        if not ReparacionesDialog.objectName():
+            ReparacionesDialog.setObjectName(u"ReparacionesDialog")
+        self.verticalLayout = QVBoxLayout(ReparacionesDialog)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.formLayout = QFormLayout()
+        self.formLayout.setObjectName(u"formLayout")
+        self.labelCliente = QLabel(ReparacionesDialog)
+        self.labelCliente.setObjectName(u"labelCliente")
+
+        self.formLayout.setWidget(0, QFormLayout.ItemRole.LabelRole, self.labelCliente)
+
+        self.lineEditCliente = QLineEdit(ReparacionesDialog)
+        self.lineEditCliente.setObjectName(u"lineEditCliente")
+
+        self.formLayout.setWidget(0, QFormLayout.ItemRole.FieldRole, self.lineEditCliente)
+
+        self.labelMarca = QLabel(ReparacionesDialog)
+        self.labelMarca.setObjectName(u"labelMarca")
+
+        self.formLayout.setWidget(1, QFormLayout.ItemRole.LabelRole, self.labelMarca)
+
+        self.lineEditMarca = QLineEdit(ReparacionesDialog)
+        self.lineEditMarca.setObjectName(u"lineEditMarca")
+
+        self.formLayout.setWidget(1, QFormLayout.ItemRole.FieldRole, self.lineEditMarca)
+
+        self.labelModelo = QLabel(ReparacionesDialog)
+        self.labelModelo.setObjectName(u"labelModelo")
+
+        self.formLayout.setWidget(2, QFormLayout.ItemRole.LabelRole, self.labelModelo)
+
+        self.lineEditModelo = QLineEdit(ReparacionesDialog)
+        self.lineEditModelo.setObjectName(u"lineEditModelo")
+
+        self.formLayout.setWidget(2, QFormLayout.ItemRole.FieldRole, self.lineEditModelo)
+
+        self.labelDescripcion = QLabel(ReparacionesDialog)
+        self.labelDescripcion.setObjectName(u"labelDescripcion")
+
+        self.formLayout.setWidget(3, QFormLayout.ItemRole.LabelRole, self.labelDescripcion)
+
+        self.plainTextDescripcion = QPlainTextEdit(ReparacionesDialog)
+        self.plainTextDescripcion.setObjectName(u"plainTextDescripcion")
+
+        self.formLayout.setWidget(3, QFormLayout.ItemRole.FieldRole, self.plainTextDescripcion)
+
+        self.labelEstado = QLabel(ReparacionesDialog)
+        self.labelEstado.setObjectName(u"labelEstado")
+
+        self.formLayout.setWidget(4, QFormLayout.ItemRole.LabelRole, self.labelEstado)
+
+        self.comboEstado = QComboBox(ReparacionesDialog)
+        self.comboEstado.addItem("")
+        self.comboEstado.addItem("")
+        self.comboEstado.setObjectName(u"comboEstado")
+
+        self.formLayout.setWidget(4, QFormLayout.ItemRole.FieldRole, self.comboEstado)
+
+        self.labelCosto = QLabel(ReparacionesDialog)
+        self.labelCosto.setObjectName(u"labelCosto")
+
+        self.formLayout.setWidget(5, QFormLayout.ItemRole.LabelRole, self.labelCosto)
+
+        self.inputCosto = QLineEdit(ReparacionesDialog)
+        self.inputCosto.setObjectName(u"inputCosto")
+
+        self.formLayout.setWidget(5, QFormLayout.ItemRole.FieldRole, self.inputCosto)
+
+
+        self.verticalLayout.addLayout(self.formLayout)
+
+        self.buttonsLayout = QHBoxLayout()
+        self.buttonsLayout.setObjectName(u"buttonsLayout")
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.buttonsLayout.addItem(self.horizontalSpacer)
+
+        self.btnGuardar = QPushButton(ReparacionesDialog)
+        self.btnGuardar.setObjectName(u"btnGuardar")
+
+        self.buttonsLayout.addWidget(self.btnGuardar)
+
+        self.btnCancelar = QPushButton(ReparacionesDialog)
+        self.btnCancelar.setObjectName(u"btnCancelar")
+
+        self.buttonsLayout.addWidget(self.btnCancelar)
+
+
+        self.verticalLayout.addLayout(self.buttonsLayout)
+
+
+        self.retranslateUi(ReparacionesDialog)
+
+        QMetaObject.connectSlotsByName(ReparacionesDialog)
+    # setupUi
+
+    def retranslateUi(self, ReparacionesDialog):
+        ReparacionesDialog.setWindowTitle(QCoreApplication.translate("ReparacionesDialog", u"Nueva Reparaci\u00f3n", None))
+        self.labelCliente.setText(QCoreApplication.translate("ReparacionesDialog", u"Cliente", None))
+        self.labelMarca.setText(QCoreApplication.translate("ReparacionesDialog", u"Marca", None))
+        self.labelModelo.setText(QCoreApplication.translate("ReparacionesDialog", u"Modelo", None))
+        self.labelDescripcion.setText(QCoreApplication.translate("ReparacionesDialog", u"Descripci\u00f3n", None))
+        self.labelEstado.setText(QCoreApplication.translate("ReparacionesDialog", u"Estado", None))
+        self.comboEstado.setItemText(0, QCoreApplication.translate("ReparacionesDialog", u"Pendiente", None))
+        self.comboEstado.setItemText(1, QCoreApplication.translate("ReparacionesDialog", u"Finalizada", None))
+
+        self.labelCosto.setText(QCoreApplication.translate("ReparacionesDialog", u"Costo", None))
+        self.inputCosto.setPlaceholderText(QCoreApplication.translate("ReparacionesDialog", u"0.00", None))
+        self.btnGuardar.setText(QCoreApplication.translate("ReparacionesDialog", u"Guardar", None))
+        self.btnCancelar.setText(QCoreApplication.translate("ReparacionesDialog", u"Cancelar", None))
+    # retranslateUi
+

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -4,6 +4,7 @@ from app.ui.ui_main_window import Ui_MainWindow
 from app.data import db
 from app.views.clientes_dialog import ClientesDialog
 from app.views.inventario_dialog import InventarioDialog
+from app.views.reparaciones_dialog import ReparacionesDialog
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -16,7 +17,7 @@ class MainWindow(QMainWindow):
         self.ui.actionClientes.triggered.connect(self._open_clientes)
         self.ui.actionDispositivos.triggered.connect(lambda: self._no_impl("Dispositivos"))
         self.ui.actionInventario.triggered.connect(self._open_inventario)
-        self.ui.actionReparaciones.triggered.connect(lambda: self._no_impl("Reparaciones"))
+        self.ui.actionReparaciones.triggered.connect(self._open_reparaciones)
 
         # Resumen inicial
         self._refresh_summary()
@@ -30,6 +31,11 @@ class MainWindow(QMainWindow):
         dlg = InventarioDialog(self)
         dlg.exec()
         self._refresh_summary()
+
+    def _open_reparaciones(self):
+        dlg = ReparacionesDialog(self)
+        if dlg.exec():
+            self._refresh_summary()
 
     def _refresh_summary(self):
         self.ui.label_total_clientes.setText(str(db.contar_clientes()))

--- a/app/views/reparaciones_dialog.py
+++ b/app/views/reparaciones_dialog.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from PySide6.QtWidgets import QDialog, QMessageBox
+
+from app.ui.ui_reparaciones import Ui_ReparacionesDialog
+from app.data import db
+
+
+class ReparacionesDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.ui = Ui_ReparacionesDialog()
+        self.ui.setupUi(self)
+
+        self.ui.btnGuardar.clicked.connect(self._guardar)
+        self.ui.btnCancelar.clicked.connect(self.reject)
+
+    def _guardar(self):
+        cliente = self.ui.lineEditCliente.text().strip()
+        marca = self.ui.lineEditMarca.text().strip()
+        modelo = self.ui.lineEditModelo.text().strip()
+        descripcion = self.ui.plainTextDescripcion.toPlainText().strip()
+        estado = self.ui.comboEstado.currentText()
+        costo_text = self.ui.inputCosto.text().strip()
+
+        if not cliente or not marca or not modelo:
+            QMessageBox.warning(self, "Validación", "Cliente, marca y modelo son obligatorios.")
+            return
+        try:
+            costo = float(costo_text) if costo_text else 0.0
+            if costo < 0:
+                raise ValueError
+        except ValueError:
+            QMessageBox.warning(self, "Validación", "Costo inválido.")
+            return
+
+        db.add_repair(cliente, marca, modelo, descripcion, costo, estado)
+        QMessageBox.information(self, "Reparación", "Reparación guardada correctamente.")
+        self.accept()


### PR DESCRIPTION
## Summary
- add reparaciones dialog and hook it to main window menu
- persist repairs with client/device helpers and cost field
- count pending repairs in dashboard after save

## Testing
- `pip install -r requirements.txt`
- `pyside6-uic app/ui/main_window.ui -o app/ui/ui_main_window.py`
- `pyside6-uic app/ui/reparaciones.ui -o app/ui/ui_reparaciones.py`
- `timeout 5 env QT_QPA_PLATFORM=offscreen python main.py`


------
https://chatgpt.com/codex/tasks/task_e_689ce20d6d38832bad292905a80876ce