### PR TITLE
feat: centralize summary counts in service

### DIFF
--- a/app/data/summary_service.py
+++ b/app/data/summary_service.py
@@ -1,0 +1,26 @@
+"""Summary service for dashboard counts."""
+from __future__ import annotations
+
+from app.data import db
+
+
+def get_counts() -> tuple[int, int, int, int]:
+    """Return counts of clients, devices, products and pending repairs.
+
+    Returns:
+        tuple: (total_clientes, total_dispositivos, total_productos, total_reparaciones_pendientes)
+        If an error occurs when retrieving a count, the affected value will be ``0``.
+    """
+    counts = []
+    funcs = (
+        db.contar_clientes,
+        db.contar_dispositivos,
+        db.contar_productos,
+        db.contar_reparaciones_pendientes,
+    )
+    for func in funcs:
+        try:
+            counts.append(func())
+        except Exception:
+            counts.append(0)
+    return tuple(counts)  # type: ignore[return-value]

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from PySide6.QtWidgets import QMainWindow, QMessageBox
 from app.ui.ui_main_window import Ui_MainWindow
-from app.data import db
+from app.data import summary_service
 from app.views.clientes_dialog import ClientesDialog
 from app.views.inventario_dialog import InventarioDialog
 from app.views.reparaciones_dialog import ReparacionesDialog
@@ -20,28 +20,36 @@ class MainWindow(QMainWindow):
         self.ui.actionReparaciones.triggered.connect(self._open_reparaciones)
 
         # Resumen inicial
-        self._refresh_summary()
+        self.refresh_summary()
 
     def _open_clientes(self):
         dlg = ClientesDialog(self)
         dlg.exec()
-        self._refresh_summary()
+        self.refresh_summary()
 
     def _open_inventario(self):
         dlg = InventarioDialog(self)
         dlg.exec()
-        self._refresh_summary()
+        self.refresh_summary()
 
     def _open_reparaciones(self):
         dlg = ReparacionesDialog(self)
         if dlg.exec():
-            self._refresh_summary()
+            self.refresh_summary()
 
-    def _refresh_summary(self):
-        self.ui.label_total_clientes.setText(str(db.contar_clientes()))
-        self.ui.label_total_dispositivos.setText(str(db.contar_dispositivos()))
-        self.ui.label_total_productos.setText(str(db.contar_productos()))
-        self.ui.label_total_reparaciones.setText(str(db.contar_reparaciones_pendientes()))
+    def refresh_summary(self):
+        total_clientes, total_dispositivos, total_productos, total_reparaciones = summary_service.get_counts()
+        self._set_label_text(["label_total_clientes", "labelTotalClientes"], total_clientes)
+        self._set_label_text(["label_total_dispositivos", "labelTotalDispositivos"], total_dispositivos)
+        self._set_label_text(["label_total_productos", "labelTotalProductos"], total_productos)
+        self._set_label_text(["label_total_reparaciones", "labelTotalReparaciones"], total_reparaciones)
+
+    def _set_label_text(self, names, value):
+        for name in names:
+            label = getattr(self.ui, name, None)
+            if label is not None:
+                label.setText(str(value))
+                break
 
     def _no_impl(self, nombre):
         QMessageBox.information(self, nombre, f"El módulo '{nombre}' aún no está implementado en este base.\n"


### PR DESCRIPTION
## Summary
- add summary service to compute dashboard counts with error handling
- use summary service in main window and refresh counts after dialog changes

## Testing
- `pip install -r requirements.txt`
- `pyside6-uic app/ui/main_window.ui -o app/ui/ui_main_window.py`
- `QT_QPA_PLATFORM=offscreen python main.py & PID=$!; sleep 5; kill $PID`

------
https://chatgpt.com/codex/tasks/task_e_689d37690898832bafdaef448c6845fd