### PR TITLE
feat: add dispositivos dialog

### DIFF
--- a/app/ui/dispositivos.ui
+++ b/app/ui/dispositivos.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DispositivosDialog</class>
+ <widget class="QDialog" name="DispositivosDialog">
+  <property name="windowTitle">
+   <string>Dispositivos</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="layoutInputs">
+     <item>
+      <widget class="QComboBox" name="comboCliente"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditMarca"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditModelo"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditIMEI"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnAgregar">
+       <property name="text">
+        <string>Agregar</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="tableDispositivos">
+     <property name="columnCount">
+      <number>4</number>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <column>
+      <property name="text">
+       <string>Cliente</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Marca</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Modelo</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>IMEI</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="layoutButtons">
+     <item>
+      <widget class="QPushButton" name="btnEliminar">
+       <property name="text">
+        <string>Eliminar</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnCerrar">
+       <property name="text">
+        <string>Cerrar</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/app/ui/ui_dispositivos.py
+++ b/app/ui/ui_dispositivos.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'dispositivos.ui'
+##
+## Created by: Qt User Interface Compiler version 6.9.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QComboBox, QDialog,
+    QHBoxLayout, QHeaderView, QLineEdit, QPushButton,
+    QSizePolicy, QSpacerItem, QTableWidget, QTableWidgetItem,
+    QVBoxLayout, QWidget)
+
+class Ui_DispositivosDialog(object):
+    def setupUi(self, DispositivosDialog):
+        if not DispositivosDialog.objectName():
+            DispositivosDialog.setObjectName(u"DispositivosDialog")
+        self.verticalLayout = QVBoxLayout(DispositivosDialog)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.layoutInputs = QHBoxLayout()
+        self.layoutInputs.setObjectName(u"layoutInputs")
+        self.comboCliente = QComboBox(DispositivosDialog)
+        self.comboCliente.setObjectName(u"comboCliente")
+
+        self.layoutInputs.addWidget(self.comboCliente)
+
+        self.lineEditMarca = QLineEdit(DispositivosDialog)
+        self.lineEditMarca.setObjectName(u"lineEditMarca")
+
+        self.layoutInputs.addWidget(self.lineEditMarca)
+
+        self.lineEditModelo = QLineEdit(DispositivosDialog)
+        self.lineEditModelo.setObjectName(u"lineEditModelo")
+
+        self.layoutInputs.addWidget(self.lineEditModelo)
+
+        self.lineEditIMEI = QLineEdit(DispositivosDialog)
+        self.lineEditIMEI.setObjectName(u"lineEditIMEI")
+
+        self.layoutInputs.addWidget(self.lineEditIMEI)
+
+        self.btnAgregar = QPushButton(DispositivosDialog)
+        self.btnAgregar.setObjectName(u"btnAgregar")
+
+        self.layoutInputs.addWidget(self.btnAgregar)
+
+
+        self.verticalLayout.addLayout(self.layoutInputs)
+
+        self.tableDispositivos = QTableWidget(DispositivosDialog)
+        if (self.tableDispositivos.columnCount() < 4):
+            self.tableDispositivos.setColumnCount(4)
+        __qtablewidgetitem = QTableWidgetItem()
+        self.tableDispositivos.setHorizontalHeaderItem(0, __qtablewidgetitem)
+        __qtablewidgetitem1 = QTableWidgetItem()
+        self.tableDispositivos.setHorizontalHeaderItem(1, __qtablewidgetitem1)
+        __qtablewidgetitem2 = QTableWidgetItem()
+        self.tableDispositivos.setHorizontalHeaderItem(2, __qtablewidgetitem2)
+        __qtablewidgetitem3 = QTableWidgetItem()
+        self.tableDispositivos.setHorizontalHeaderItem(3, __qtablewidgetitem3)
+        self.tableDispositivos.setObjectName(u"tableDispositivos")
+        self.tableDispositivos.setColumnCount(4)
+        self.tableDispositivos.setSelectionBehavior(QAbstractItemView.SelectRows)
+
+        self.verticalLayout.addWidget(self.tableDispositivos)
+
+        self.layoutButtons = QHBoxLayout()
+        self.layoutButtons.setObjectName(u"layoutButtons")
+        self.btnEliminar = QPushButton(DispositivosDialog)
+        self.btnEliminar.setObjectName(u"btnEliminar")
+
+        self.layoutButtons.addWidget(self.btnEliminar)
+
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.layoutButtons.addItem(self.horizontalSpacer)
+
+        self.btnCerrar = QPushButton(DispositivosDialog)
+        self.btnCerrar.setObjectName(u"btnCerrar")
+
+        self.layoutButtons.addWidget(self.btnCerrar)
+
+
+        self.verticalLayout.addLayout(self.layoutButtons)
+
+
+        self.retranslateUi(DispositivosDialog)
+
+        QMetaObject.connectSlotsByName(DispositivosDialog)
+    # setupUi
+
+    def retranslateUi(self, DispositivosDialog):
+        DispositivosDialog.setWindowTitle(QCoreApplication.translate("DispositivosDialog", u"Dispositivos", None))
+        self.btnAgregar.setText(QCoreApplication.translate("DispositivosDialog", u"Agregar", None))
+        ___qtablewidgetitem = self.tableDispositivos.horizontalHeaderItem(0)
+        ___qtablewidgetitem.setText(QCoreApplication.translate("DispositivosDialog", u"Cliente", None));
+        ___qtablewidgetitem1 = self.tableDispositivos.horizontalHeaderItem(1)
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("DispositivosDialog", u"Marca", None));
+        ___qtablewidgetitem2 = self.tableDispositivos.horizontalHeaderItem(2)
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("DispositivosDialog", u"Modelo", None));
+        ___qtablewidgetitem3 = self.tableDispositivos.horizontalHeaderItem(3)
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("DispositivosDialog", u"IMEI", None));
+        self.btnEliminar.setText(QCoreApplication.translate("DispositivosDialog", u"Eliminar", None))
+        self.btnCerrar.setText(QCoreApplication.translate("DispositivosDialog", u"Cerrar", None))
+    # retranslateUi
+

--- a/app/views/dispositivos_dialog.py
+++ b/app/views/dispositivos_dialog.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+from PySide6.QtWidgets import QDialog, QMessageBox, QTableWidgetItem
+from PySide6.QtCore import Qt
+
+from app.ui.ui_dispositivos import Ui_DispositivosDialog
+from app.data import db
+
+
+class DispositivosDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.ui = Ui_DispositivosDialog()
+        self.ui.setupUi(self)
+
+        self._updating = False
+        self._changed = False
+
+        self.ui.btnAgregar.clicked.connect(self.agregar)
+        self.ui.btnEliminar.clicked.connect(self.eliminar)
+        self.ui.btnCerrar.clicked.connect(self.cerrar)
+        self.ui.tableDispositivos.itemChanged.connect(self._item_changed)
+
+        self._load_clientes()
+        self._load_dispositivos()
+
+    def _load_clientes(self):
+        combo = self.ui.comboCliente
+        combo.clear()
+        for cid, nombre in db.listar_clientes():
+            combo.addItem(nombre, cid)
+
+    def _load_dispositivos(self):
+        self._updating = True
+        table = self.ui.tableDispositivos
+        table.setRowCount(0)
+        for row, (did, cid, cname, marca, modelo, imei) in enumerate(db.listar_dispositivos()):
+            table.insertRow(row)
+            cliente_item = QTableWidgetItem(cname)
+            cliente_item.setFlags(cliente_item.flags() & ~Qt.ItemIsEditable)
+            marca_item = QTableWidgetItem(marca or "")
+            marca_item.setData(Qt.UserRole, did)
+            modelo_item = QTableWidgetItem(modelo or "")
+            imei_item = QTableWidgetItem(imei or "")
+            table.setItem(row, 0, cliente_item)
+            table.setItem(row, 1, marca_item)
+            table.setItem(row, 2, modelo_item)
+            table.setItem(row, 3, imei_item)
+        table.resizeColumnsToContents()
+        self._updating = False
+
+    def agregar(self):
+        cid = self.ui.comboCliente.currentData()
+        marca = self.ui.lineEditMarca.text().strip()
+        modelo = self.ui.lineEditModelo.text().strip()
+        imei = self.ui.lineEditIMEI.text().strip()
+        if cid is None:
+            QMessageBox.warning(self, "Validación", "Seleccione un cliente.")
+            return
+        if not marca or not modelo:
+            QMessageBox.warning(self, "Validación", "Marca y modelo son obligatorios.")
+            return
+        db.add_device(cid, marca, modelo, imei or None)
+        self._changed = True
+        self.ui.lineEditMarca.clear()
+        self.ui.lineEditModelo.clear()
+        self.ui.lineEditIMEI.clear()
+        self._load_dispositivos()
+
+    def _item_changed(self, item):
+        if self._updating or item.column() not in (1, 2, 3):
+            return
+        row = item.row()
+        marca_item = self.ui.tableDispositivos.item(row, 1)
+        did = marca_item.data(Qt.UserRole)
+        marca = marca_item.text().strip()
+        modelo = self.ui.tableDispositivos.item(row, 2).text().strip()
+        imei_item = self.ui.tableDispositivos.item(row, 3)
+        imei = imei_item.text().strip() if imei_item else ""
+        if not marca or not modelo:
+            QMessageBox.warning(self, "Validación", "Marca y modelo no pueden estar vacíos.")
+            self._load_dispositivos()
+            return
+        db.update_device(did, marca=marca, modelo=modelo, imei=imei or None)
+        self._changed = True
+
+    def eliminar(self):
+        row = self.ui.tableDispositivos.currentRow()
+        if row < 0:
+            QMessageBox.warning(self, "Eliminar", "Seleccione un dispositivo.")
+            return
+        marca_item = self.ui.tableDispositivos.item(row, 1)
+        did = marca_item.data(Qt.UserRole)
+        if QMessageBox.question(self, "Confirmar", "¿Eliminar dispositivo seleccionado?") == QMessageBox.Yes:
+            db.delete_device(did)
+            self._changed = True
+            self._load_dispositivos()
+
+    def cerrar(self):
+        if self._changed:
+            self.accept()
+        else:
+            self.reject()
+
+    def reject(self):  # type: ignore[override]
+        self.cerrar()

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -5,6 +5,7 @@ from app.data import summary_service
 from app.views.clientes_dialog import ClientesDialog
 from app.views.inventario_dialog import InventarioDialog
 from app.views.reparaciones_dialog import ReparacionesDialog
+from app.views.dispositivos_dialog import DispositivosDialog
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -15,7 +16,7 @@ class MainWindow(QMainWindow):
         # Conexión de acciones del menú
         self.ui.actionSalir.triggered.connect(self.close)
         self.ui.actionClientes.triggered.connect(self._open_clientes)
-        self.ui.actionDispositivos.triggered.connect(lambda: self._no_impl("Dispositivos"))
+        self.ui.actionDispositivos.triggered.connect(self._open_dispositivos)
         self.ui.actionInventario.triggered.connect(self._open_inventario)
         self.ui.actionReparaciones.triggered.connect(self._open_reparaciones)
 
@@ -34,6 +35,11 @@ class MainWindow(QMainWindow):
 
     def _open_reparaciones(self):
         dlg = ReparacionesDialog(self)
+        if dlg.exec():
+            self.refresh_summary()
+
+    def _open_dispositivos(self):
+        dlg = DispositivosDialog(self)
         if dlg.exec():
             self.refresh_summary()
 


### PR DESCRIPTION
## Summary
- add QDialog UI for managing devices with clients, brand, model and IMEI
- implement DispositivosDialog for adding, editing and deleting devices
- extend SQLite helpers and hook dialog into main menu

## Testing
- `pip install -r requirements.txt`
- `pyside6-uic app/ui/main_window.ui -o app/ui/ui_main_window.py`
- `pyside6-uic app/ui/dispositivos.ui -o app/ui/ui_dispositivos.py`
- `QT_QPA_PLATFORM=offscreen python main.py`


------
https://chatgpt.com/codex/tasks/task_e_689d3a2dfd64832ba66f8f3aad324796