### PR TITLE
Fix device dialog closing recursion error

### DIFF
--- a/app/views/dispositivos_dialog.py
+++ b/app/views/dispositivos_dialog.py
@@ -99,9 +99,9 @@ class DispositivosDialog(QDialog):
 
     def cerrar(self):
         if self._changed:
-            self.accept()
+            super().accept()
         else:
-            self.reject()
+            super().reject()
 
     def reject(self):  # type: ignore[override]
         self.cerrar()


### PR DESCRIPTION
## Summary
- prevent RecursionError in device dialog by calling base reject/accept

## Testing
- `make doctor`


------
https://chatgpt.com/codex/tasks/task_e_689d4316b408832bb51f19b8a34dfb2f