### PR TITLE
Expand client management with extra fields and validation

### DIFF
--- a/app/ui/clientes.ui
+++ b/app/ui/clientes.ui
@@ -7,14 +7,82 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelNombre">
+       <property name="text">
+        <string>Nombre</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
       <widget class="QLineEdit" name="lineEditNombre"/>
      </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelTelefono">
+       <property name="text">
+        <string>Teléfono</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lineEditTelefono"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelEmail">
+       <property name="text">
+        <string>Email</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="lineEditEmail"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelDireccion">
+       <property name="text">
+        <string>Dirección</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="lineEditDireccion"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelNif">
+       <property name="text">
+        <string>NIF</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="lineEditNif"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelNotas">
+       <property name="text">
+        <string>Notas</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QPlainTextEdit" name="plainTextEditNotas"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutBtns">
      <item>
       <widget class="QPushButton" name="btnAgregar">
        <property name="text">
         <string>Agregar</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnGuardar">
+       <property name="text">
+        <string>Guardar cambios</string>
        </property>
       </widget>
      </item>
@@ -23,7 +91,7 @@
    <item>
     <widget class="QTableWidget" name="tableClientes">
      <property name="columnCount">
-      <number>2</number>
+      <number>4</number>
      </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
@@ -39,6 +107,16 @@
      <column>
       <property name="text">
        <string>Nombre</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Teléfono</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Email</string>
       </property>
      </column>
     </widget>
@@ -79,3 +157,4 @@
  <resources/>
  <connections/>
 </ui>
+

--- a/app/ui/ui_clientes.py
+++ b/app/ui/ui_clientes.py
@@ -15,10 +15,10 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QAbstractItemView, QApplication, QDialog, QHBoxLayout,
-    QHeaderView, QLineEdit, QPushButton, QSizePolicy,
-    QSpacerItem, QTableWidget, QTableWidgetItem, QVBoxLayout,
-    QWidget)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QDialog, QFormLayout,
+    QHBoxLayout, QHeaderView, QLabel, QLineEdit,
+    QPlainTextEdit, QPushButton, QSizePolicy, QSpacerItem,
+    QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget)
 
 class Ui_ClientesDialog(object):
     def setupUi(self, ClientesDialog):
@@ -26,30 +26,99 @@ class Ui_ClientesDialog(object):
             ClientesDialog.setObjectName(u"ClientesDialog")
         self.verticalLayout = QVBoxLayout(ClientesDialog)
         self.verticalLayout.setObjectName(u"verticalLayout")
-        self.horizontalLayout = QHBoxLayout()
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.formLayout = QFormLayout()
+        self.formLayout.setObjectName(u"formLayout")
+        self.labelNombre = QLabel(ClientesDialog)
+        self.labelNombre.setObjectName(u"labelNombre")
+
+        self.formLayout.setWidget(0, QFormLayout.ItemRole.LabelRole, self.labelNombre)
+
         self.lineEditNombre = QLineEdit(ClientesDialog)
         self.lineEditNombre.setObjectName(u"lineEditNombre")
 
-        self.horizontalLayout.addWidget(self.lineEditNombre)
+        self.formLayout.setWidget(0, QFormLayout.ItemRole.FieldRole, self.lineEditNombre)
 
+        self.labelTelefono = QLabel(ClientesDialog)
+        self.labelTelefono.setObjectName(u"labelTelefono")
+
+        self.formLayout.setWidget(1, QFormLayout.ItemRole.LabelRole, self.labelTelefono)
+
+        self.lineEditTelefono = QLineEdit(ClientesDialog)
+        self.lineEditTelefono.setObjectName(u"lineEditTelefono")
+
+        self.formLayout.setWidget(1, QFormLayout.ItemRole.FieldRole, self.lineEditTelefono)
+
+        self.labelEmail = QLabel(ClientesDialog)
+        self.labelEmail.setObjectName(u"labelEmail")
+
+        self.formLayout.setWidget(2, QFormLayout.ItemRole.LabelRole, self.labelEmail)
+
+        self.lineEditEmail = QLineEdit(ClientesDialog)
+        self.lineEditEmail.setObjectName(u"lineEditEmail")
+
+        self.formLayout.setWidget(2, QFormLayout.ItemRole.FieldRole, self.lineEditEmail)
+
+        self.labelDireccion = QLabel(ClientesDialog)
+        self.labelDireccion.setObjectName(u"labelDireccion")
+
+        self.formLayout.setWidget(3, QFormLayout.ItemRole.LabelRole, self.labelDireccion)
+
+        self.lineEditDireccion = QLineEdit(ClientesDialog)
+        self.lineEditDireccion.setObjectName(u"lineEditDireccion")
+
+        self.formLayout.setWidget(3, QFormLayout.ItemRole.FieldRole, self.lineEditDireccion)
+
+        self.labelNif = QLabel(ClientesDialog)
+        self.labelNif.setObjectName(u"labelNif")
+
+        self.formLayout.setWidget(4, QFormLayout.ItemRole.LabelRole, self.labelNif)
+
+        self.lineEditNif = QLineEdit(ClientesDialog)
+        self.lineEditNif.setObjectName(u"lineEditNif")
+
+        self.formLayout.setWidget(4, QFormLayout.ItemRole.FieldRole, self.lineEditNif)
+
+        self.labelNotas = QLabel(ClientesDialog)
+        self.labelNotas.setObjectName(u"labelNotas")
+
+        self.formLayout.setWidget(5, QFormLayout.ItemRole.LabelRole, self.labelNotas)
+
+        self.plainTextEditNotas = QPlainTextEdit(ClientesDialog)
+        self.plainTextEditNotas.setObjectName(u"plainTextEditNotas")
+
+        self.formLayout.setWidget(5, QFormLayout.ItemRole.FieldRole, self.plainTextEditNotas)
+
+
+        self.verticalLayout.addLayout(self.formLayout)
+
+        self.horizontalLayoutBtns = QHBoxLayout()
+        self.horizontalLayoutBtns.setObjectName(u"horizontalLayoutBtns")
         self.btnAgregar = QPushButton(ClientesDialog)
         self.btnAgregar.setObjectName(u"btnAgregar")
 
-        self.horizontalLayout.addWidget(self.btnAgregar)
+        self.horizontalLayoutBtns.addWidget(self.btnAgregar)
+
+        self.btnGuardar = QPushButton(ClientesDialog)
+        self.btnGuardar.setObjectName(u"btnGuardar")
+
+        self.horizontalLayoutBtns.addWidget(self.btnGuardar)
 
 
-        self.verticalLayout.addLayout(self.horizontalLayout)
+        self.verticalLayout.addLayout(self.horizontalLayoutBtns)
 
         self.tableClientes = QTableWidget(ClientesDialog)
-        if (self.tableClientes.columnCount() < 2):
-            self.tableClientes.setColumnCount(2)
+        if (self.tableClientes.columnCount() < 4):
+            self.tableClientes.setColumnCount(4)
         __qtablewidgetitem = QTableWidgetItem()
         self.tableClientes.setHorizontalHeaderItem(0, __qtablewidgetitem)
         __qtablewidgetitem1 = QTableWidgetItem()
         self.tableClientes.setHorizontalHeaderItem(1, __qtablewidgetitem1)
+        __qtablewidgetitem2 = QTableWidgetItem()
+        self.tableClientes.setHorizontalHeaderItem(2, __qtablewidgetitem2)
+        __qtablewidgetitem3 = QTableWidgetItem()
+        self.tableClientes.setHorizontalHeaderItem(3, __qtablewidgetitem3)
         self.tableClientes.setObjectName(u"tableClientes")
-        self.tableClientes.setColumnCount(2)
+        self.tableClientes.setColumnCount(4)
         self.tableClientes.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.tableClientes.setEditTriggers(QAbstractItemView.NoEditTriggers)
 
@@ -82,11 +151,22 @@ class Ui_ClientesDialog(object):
 
     def retranslateUi(self, ClientesDialog):
         ClientesDialog.setWindowTitle(QCoreApplication.translate("ClientesDialog", u"Clientes", None))
+        self.labelNombre.setText(QCoreApplication.translate("ClientesDialog", u"Nombre", None))
+        self.labelTelefono.setText(QCoreApplication.translate("ClientesDialog", u"Tel\u00e9fono", None))
+        self.labelEmail.setText(QCoreApplication.translate("ClientesDialog", u"Email", None))
+        self.labelDireccion.setText(QCoreApplication.translate("ClientesDialog", u"Direcci\u00f3n", None))
+        self.labelNif.setText(QCoreApplication.translate("ClientesDialog", u"NIF", None))
+        self.labelNotas.setText(QCoreApplication.translate("ClientesDialog", u"Notas", None))
         self.btnAgregar.setText(QCoreApplication.translate("ClientesDialog", u"Agregar", None))
+        self.btnGuardar.setText(QCoreApplication.translate("ClientesDialog", u"Guardar cambios", None))
         ___qtablewidgetitem = self.tableClientes.horizontalHeaderItem(0)
         ___qtablewidgetitem.setText(QCoreApplication.translate("ClientesDialog", u"ID", None));
         ___qtablewidgetitem1 = self.tableClientes.horizontalHeaderItem(1)
         ___qtablewidgetitem1.setText(QCoreApplication.translate("ClientesDialog", u"Nombre", None));
+        ___qtablewidgetitem2 = self.tableClientes.horizontalHeaderItem(2)
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("ClientesDialog", u"Tel\u00e9fono", None));
+        ___qtablewidgetitem3 = self.tableClientes.horizontalHeaderItem(3)
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("ClientesDialog", u"Email", None));
         self.btnEliminar.setText(QCoreApplication.translate("ClientesDialog", u"Eliminar", None))
         self.btnCerrar.setText(QCoreApplication.translate("ClientesDialog", u"Cerrar", None))
     # retranslateUi

--- a/app/views/clientes_dialog.py
+++ b/app/views/clientes_dialog.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from PySide6.QtWidgets import QDialog, QMessageBox, QTableWidgetItem
+from PySide6.QtGui import QRegularExpressionValidator
+from PySide6.QtCore import QRegularExpression
+
 from app.ui.ui_clientes import Ui_ClientesDialog
 from app.data import db
 
@@ -10,30 +13,138 @@ class ClientesDialog(QDialog):
         self.ui = Ui_ClientesDialog()
         self.ui.setupUi(self)
 
+        phone_regex = QRegularExpression(r"^$|[0-9 +]+$")
+        email_regex = QRegularExpression(r"^$|[^@\s]+@[^@\s]+\.[^@\s]+$")
+        self.ui.lineEditTelefono.setValidator(QRegularExpressionValidator(phone_regex, self))
+        self.ui.lineEditEmail.setValidator(QRegularExpressionValidator(email_regex, self))
+
         self.ui.btnAgregar.clicked.connect(self.agregar)
+        self.ui.btnGuardar.clicked.connect(self.guardar_cambios)
         self.ui.btnEliminar.clicked.connect(self.eliminar)
         self.ui.btnCerrar.clicked.connect(self.close)
+        self.ui.tableClientes.itemSelectionChanged.connect(self.cargar_seleccion)
 
+        self._clientes = {}
         self._load_clientes()
 
-    def _load_clientes(self):
-        self.ui.tableClientes.setRowCount(0)
-        for row, (cid, nombre) in enumerate(db.listar_clientes()):
-            self.ui.tableClientes.insertRow(row)
-            self.ui.tableClientes.setItem(row, 0, QTableWidgetItem(str(cid)))
-            self.ui.tableClientes.setItem(row, 1, QTableWidgetItem(nombre))
-        self.ui.tableClientes.resizeColumnsToContents()
+    def _load_clientes(self) -> None:
+        table = self.ui.tableClientes
+        table.setRowCount(0)
+        self._clientes = {}
+        for row, (cid, nombre, telefono, email, direccion, nif, notas) in enumerate(
+            db.listar_clientes_detallado()
+        ):
+            self._clientes[cid] = {
+                "nombre": nombre or "",
+                "telefono": telefono or "",
+                "email": email or "",
+                "direccion": direccion or "",
+                "nif": nif or "",
+                "notas": notas or "",
+            }
+            table.insertRow(row)
+            table.setItem(row, 0, QTableWidgetItem(str(cid)))
+            table.setItem(row, 1, QTableWidgetItem(nombre or ""))
+            table.setItem(row, 2, QTableWidgetItem(telefono or ""))
+            table.setItem(row, 3, QTableWidgetItem(email or ""))
+        table.resizeColumnsToContents()
 
-    def agregar(self):
+    def _clear_form(self) -> None:
+        self.ui.lineEditNombre.clear()
+        self.ui.lineEditTelefono.clear()
+        self.ui.lineEditEmail.clear()
+        self.ui.lineEditDireccion.clear()
+        self.ui.lineEditNif.clear()
+        self.ui.plainTextEditNotas.clear()
+        self.ui.tableClientes.clearSelection()
+
+    def agregar(self) -> None:
         nombre = self.ui.lineEditNombre.text().strip()
+        telefono = self.ui.lineEditTelefono.text().strip()
+        email = self.ui.lineEditEmail.text().strip()
+        direccion = self.ui.lineEditDireccion.text().strip()
+        nif = self.ui.lineEditNif.text().strip()
+        notas = self.ui.plainTextEditNotas.toPlainText().strip()
+
         if not nombre:
             QMessageBox.warning(self, "Validación", "El nombre no puede estar vacío.")
             return
-        db.add_cliente(nombre)
-        self.ui.lineEditNombre.clear()
+        if email and not self.ui.lineEditEmail.hasAcceptableInput():
+            QMessageBox.warning(self, "Validación", "Email no válido.")
+            return
+        if telefono and not self.ui.lineEditTelefono.hasAcceptableInput():
+            QMessageBox.warning(self, "Validación", "Teléfono no válido.")
+            return
+
+        db.add_cliente(
+            nombre,
+            telefono=telefono or None,
+            email=email or None,
+            direccion=direccion or None,
+            nif=nif or None,
+            notas=notas or None,
+        )
+        self._clear_form()
         self._load_clientes()
 
-    def eliminar(self):
+    def cargar_seleccion(self) -> None:
+        row = self.ui.tableClientes.currentRow()
+        if row < 0:
+            return
+        cid_item = self.ui.tableClientes.item(row, 0)
+        if not cid_item:
+            return
+        cid = int(cid_item.text())
+        cliente = self._clientes.get(cid)
+        if not cliente:
+            return
+        self.ui.lineEditNombre.setText(cliente["nombre"])
+        self.ui.lineEditTelefono.setText(cliente["telefono"])
+        self.ui.lineEditEmail.setText(cliente["email"])
+        self.ui.lineEditDireccion.setText(cliente["direccion"])
+        self.ui.lineEditNif.setText(cliente["nif"])
+        self.ui.plainTextEditNotas.setPlainText(cliente["notas"])
+
+    def guardar_cambios(self) -> None:
+        row = self.ui.tableClientes.currentRow()
+        if row < 0:
+            QMessageBox.warning(self, "Guardar", "Seleccione un cliente.")
+            return
+        cid_item = self.ui.tableClientes.item(row, 0)
+        if not cid_item:
+            return
+        cid = int(cid_item.text())
+
+        nombre = self.ui.lineEditNombre.text().strip()
+        telefono = self.ui.lineEditTelefono.text().strip()
+        email = self.ui.lineEditEmail.text().strip()
+        direccion = self.ui.lineEditDireccion.text().strip()
+        nif = self.ui.lineEditNif.text().strip()
+        notas = self.ui.plainTextEditNotas.toPlainText().strip()
+
+        if not nombre:
+            QMessageBox.warning(self, "Validación", "El nombre no puede estar vacío.")
+            return
+        if email and not self.ui.lineEditEmail.hasAcceptableInput():
+            QMessageBox.warning(self, "Validación", "Email no válido.")
+            return
+        if telefono and not self.ui.lineEditTelefono.hasAcceptableInput():
+            QMessageBox.warning(self, "Validación", "Teléfono no válido.")
+            return
+
+        db.update_cliente(
+            cid,
+            nombre=nombre,
+            telefono=telefono or None,
+            email=email or None,
+            direccion=direccion or None,
+            nif=nif or None,
+            notas=notas or None,
+        )
+        self._clear_form()
+        self._load_clientes()
+
+    def eliminar(self) -> None:
         row = self.ui.tableClientes.currentRow()
         if row < 0:
             QMessageBox.warning(self, "Eliminar", "Seleccione un cliente.")
@@ -44,4 +155,6 @@ class ClientesDialog(QDialog):
         cid = int(id_item.text())
         if QMessageBox.question(self, "Confirmar", "¿Eliminar cliente seleccionado?") == QMessageBox.Yes:
             db.delete_cliente(cid)
+            self._clear_form()
             self._load_clientes()
+


### PR DESCRIPTION
## Summary
- Add phone, email, address, NIF and notes fields to clients dialog UI and display table columns
- Allow creating and updating clients with validation for phone numbers and emails
- Provide database helpers for detailed client listing and updates

## Testing
- `pyside6-uic app/ui/clientes.ui -o app/ui/ui_clientes.py`
- `python -m py_compile app/data/db.py app/views/clientes_dialog.py`
- `make doctor` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689d4b274bbc832b8f5f6557153646db