### PR TITLE
feat: expand device fields and inline editing

### DIFF
--- a/app/ui/dispositivos.ui
+++ b/app/ui/dispositivos.ui
@@ -14,11 +14,20 @@
      <item>
       <widget class="QLineEdit" name="lineEditMarca"/>
      </item>
-     <item>
+    <item>
       <widget class="QLineEdit" name="lineEditModelo"/>
      </item>
      <item>
       <widget class="QLineEdit" name="lineEditIMEI"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditSerie"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditColor"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEditAccesorios"/>
      </item>
      <item>
       <widget class="QPushButton" name="btnAgregar">
@@ -32,7 +41,7 @@
    <item>
     <widget class="QTableWidget" name="tableDispositivos">
      <property name="columnCount">
-      <number>4</number>
+      <number>7</number>
      </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
@@ -55,6 +64,21 @@
      <column>
       <property name="text">
        <string>IMEI</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Nº Serie</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Color</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Accesorios</string>
       </property>
      </column>
     </widget>

--- a/app/ui/ui_dispositivos.py
+++ b/app/ui/ui_dispositivos.py
@@ -48,6 +48,21 @@ class Ui_DispositivosDialog(object):
 
         self.layoutInputs.addWidget(self.lineEditIMEI)
 
+        self.lineEditSerie = QLineEdit(DispositivosDialog)
+        self.lineEditSerie.setObjectName(u"lineEditSerie")
+
+        self.layoutInputs.addWidget(self.lineEditSerie)
+
+        self.lineEditColor = QLineEdit(DispositivosDialog)
+        self.lineEditColor.setObjectName(u"lineEditColor")
+
+        self.layoutInputs.addWidget(self.lineEditColor)
+
+        self.lineEditAccesorios = QLineEdit(DispositivosDialog)
+        self.lineEditAccesorios.setObjectName(u"lineEditAccesorios")
+
+        self.layoutInputs.addWidget(self.lineEditAccesorios)
+
         self.btnAgregar = QPushButton(DispositivosDialog)
         self.btnAgregar.setObjectName(u"btnAgregar")
 
@@ -57,8 +72,8 @@ class Ui_DispositivosDialog(object):
         self.verticalLayout.addLayout(self.layoutInputs)
 
         self.tableDispositivos = QTableWidget(DispositivosDialog)
-        if (self.tableDispositivos.columnCount() < 4):
-            self.tableDispositivos.setColumnCount(4)
+        if (self.tableDispositivos.columnCount() < 7):
+            self.tableDispositivos.setColumnCount(7)
         __qtablewidgetitem = QTableWidgetItem()
         self.tableDispositivos.setHorizontalHeaderItem(0, __qtablewidgetitem)
         __qtablewidgetitem1 = QTableWidgetItem()
@@ -67,8 +82,14 @@ class Ui_DispositivosDialog(object):
         self.tableDispositivos.setHorizontalHeaderItem(2, __qtablewidgetitem2)
         __qtablewidgetitem3 = QTableWidgetItem()
         self.tableDispositivos.setHorizontalHeaderItem(3, __qtablewidgetitem3)
+        __qtablewidgetitem4 = QTableWidgetItem()
+        self.tableDispositivos.setHorizontalHeaderItem(4, __qtablewidgetitem4)
+        __qtablewidgetitem5 = QTableWidgetItem()
+        self.tableDispositivos.setHorizontalHeaderItem(5, __qtablewidgetitem5)
+        __qtablewidgetitem6 = QTableWidgetItem()
+        self.tableDispositivos.setHorizontalHeaderItem(6, __qtablewidgetitem6)
         self.tableDispositivos.setObjectName(u"tableDispositivos")
-        self.tableDispositivos.setColumnCount(4)
+        self.tableDispositivos.setColumnCount(7)
         self.tableDispositivos.setSelectionBehavior(QAbstractItemView.SelectRows)
 
         self.verticalLayout.addWidget(self.tableDispositivos)
@@ -109,6 +130,12 @@ class Ui_DispositivosDialog(object):
         ___qtablewidgetitem2.setText(QCoreApplication.translate("DispositivosDialog", u"Modelo", None));
         ___qtablewidgetitem3 = self.tableDispositivos.horizontalHeaderItem(3)
         ___qtablewidgetitem3.setText(QCoreApplication.translate("DispositivosDialog", u"IMEI", None));
+        ___qtablewidgetitem4 = self.tableDispositivos.horizontalHeaderItem(4)
+        ___qtablewidgetitem4.setText(QCoreApplication.translate("DispositivosDialog", u"N\u00ba Serie", None));
+        ___qtablewidgetitem5 = self.tableDispositivos.horizontalHeaderItem(5)
+        ___qtablewidgetitem5.setText(QCoreApplication.translate("DispositivosDialog", u"Color", None));
+        ___qtablewidgetitem6 = self.tableDispositivos.horizontalHeaderItem(6)
+        ___qtablewidgetitem6.setText(QCoreApplication.translate("DispositivosDialog", u"Accesorios", None));
         self.btnEliminar.setText(QCoreApplication.translate("DispositivosDialog", u"Eliminar", None))
         self.btnCerrar.setText(QCoreApplication.translate("DispositivosDialog", u"Cerrar", None))
     # retranslateUi

--- a/app/views/dispositivos_dialog.py
+++ b/app/views/dispositivos_dialog.py
@@ -34,18 +34,35 @@ class DispositivosDialog(QDialog):
         table = self.ui.tableDispositivos
         table.blockSignals(True)
         table.setRowCount(0)
-        for row, (did, cid, cname, marca, modelo, imei) in enumerate(db.listar_dispositivos()):
+        for row, (
+            did,
+            cid,
+            cname,
+            marca,
+            modelo,
+            imei,
+            n_serie,
+            color,
+            accesorios,
+        ) in enumerate(db.listar_dispositivos_detallado()):
             table.insertRow(row)
             cliente_item = QTableWidgetItem(cname)
             cliente_item.setFlags(cliente_item.flags() & ~Qt.ItemIsEditable)
             marca_item = QTableWidgetItem(marca or "")
             marca_item.setData(Qt.UserRole, did)
+            marca_item.setFlags(marca_item.flags() & ~Qt.ItemIsEditable)
             modelo_item = QTableWidgetItem(modelo or "")
             imei_item = QTableWidgetItem(imei or "")
+            serie_item = QTableWidgetItem(n_serie or "")
+            color_item = QTableWidgetItem(color or "")
+            accesorios_item = QTableWidgetItem(accesorios or "")
             table.setItem(row, 0, cliente_item)
             table.setItem(row, 1, marca_item)
             table.setItem(row, 2, modelo_item)
             table.setItem(row, 3, imei_item)
+            table.setItem(row, 4, serie_item)
+            table.setItem(row, 5, color_item)
+            table.setItem(row, 6, accesorios_item)
         table.resizeColumnsToContents()
         table.blockSignals(False)
         self._updating = False
@@ -55,34 +72,60 @@ class DispositivosDialog(QDialog):
         marca = self.ui.lineEditMarca.text().strip()
         modelo = self.ui.lineEditModelo.text().strip()
         imei = self.ui.lineEditIMEI.text().strip()
+        n_serie = self.ui.lineEditSerie.text().strip()
+        color = self.ui.lineEditColor.text().strip()
+        accesorios = self.ui.lineEditAccesorios.text().strip()
         if cid is None:
             QMessageBox.warning(self, "Validación", "Seleccione un cliente.")
             return
         if not marca or not modelo:
             QMessageBox.warning(self, "Validación", "Marca y modelo son obligatorios.")
             return
-        db.add_device(cid, marca, modelo, imei or None)
+        db.add_device(
+            cid,
+            marca,
+            modelo,
+            imei or None,
+            n_serie or None,
+            color or None,
+            accesorios or None,
+        )
         self._changed = True
         self.ui.lineEditMarca.clear()
         self.ui.lineEditModelo.clear()
         self.ui.lineEditIMEI.clear()
+        self.ui.lineEditSerie.clear()
+        self.ui.lineEditColor.clear()
+        self.ui.lineEditAccesorios.clear()
         self._load_dispositivos()
 
     def _item_changed(self, item):
-        if self._updating or item.column() not in (1, 2, 3):
+        if self._updating or item.column() not in (2, 3, 4, 5, 6):
             return
         row = item.row()
         marca_item = self.ui.tableDispositivos.item(row, 1)
         did = marca_item.data(Qt.UserRole)
-        marca = marca_item.text().strip()
         modelo = self.ui.tableDispositivos.item(row, 2).text().strip()
         imei_item = self.ui.tableDispositivos.item(row, 3)
         imei = imei_item.text().strip() if imei_item else ""
-        if not marca or not modelo:
-            QMessageBox.warning(self, "Validación", "Marca y modelo no pueden estar vacíos.")
+        serie_item = self.ui.tableDispositivos.item(row, 4)
+        n_serie = serie_item.text().strip() if serie_item else ""
+        color_item = self.ui.tableDispositivos.item(row, 5)
+        color = color_item.text().strip() if color_item else ""
+        accesorios_item = self.ui.tableDispositivos.item(row, 6)
+        accesorios = accesorios_item.text().strip() if accesorios_item else ""
+        if not modelo:
+            QMessageBox.warning(self, "Validación", "Modelo no puede estar vacío.")
             self._load_dispositivos()
             return
-        db.update_device(did, marca=marca, modelo=modelo, imei=imei or None)
+        db.update_device(
+            did,
+            modelo=modelo,
+            imei=imei or None,
+            n_serie=n_serie or None,
+            color=color or None,
+            accesorios=accesorios or None,
+        )
         self._changed = True
 
     def eliminar(self):


### PR DESCRIPTION
## Summary
- expand device dialog to handle IMEI, serie, color and accesorios
- support detailed device listing and flexible updates in DB
- allow inline editing for modelo, IMEI, serie, color and accesorios

## Testing
- `python -m py_compile app/data/db.py app/views/dispositivos_dialog.py`
- `make doctor` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689d4c467924832baec7263e1cb547bb