### PR TITLE
Enhance inventory dialog with extended product fields

### DIFF
--- a/app/ui/inventario.ui
+++ b/app/ui/inventario.ui
@@ -7,18 +7,61 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="layoutInputs">
-     <item>
+    <layout class="QGridLayout" name="layoutInputs">
+     <item row="0" column="0">
+      <widget class="QLineEdit" name="lineEditSKU"/>
+     </item>
+     <item row="0" column="1">
       <widget class="QLineEdit" name="lineEditNombre"/>
      </item>
-     <item>
+     <item row="0" column="2">
+      <widget class="QComboBox" name="comboCategoria">
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
       <widget class="QSpinBox" name="spinCantidad">
        <property name="minimum">
         <number>0</number>
        </property>
       </widget>
      </item>
-     <item>
+     <item row="0" column="4">
+      <widget class="QSpinBox" name="spinStockMin">
+       <property name="minimum">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QDoubleSpinBox" name="doubleCosto">
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="minimum">
+        <double>0.0</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="doublePrecio">
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="minimum">
+        <double>0.0</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLineEdit" name="lineUbicacion"/>
+     </item>
+     <item row="1" column="3">
+      <widget class="QLineEdit" name="lineProveedor"/>
+     </item>
+     <item row="1" column="4">
       <widget class="QPushButton" name="btnAgregar">
        <property name="text">
         <string>Agregar</string>
@@ -30,11 +73,16 @@
    <item>
     <widget class="QTableWidget" name="tableProductos">
      <property name="columnCount">
-      <number>2</number>
+      <number>9</number>
      </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
+     <column>
+      <property name="text">
+       <string>SKU</string>
+      </property>
+     </column>
      <column>
       <property name="text">
        <string>Nombre</string>
@@ -42,7 +90,37 @@
      </column>
      <column>
       <property name="text">
+       <string>Categoría</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
        <string>Cantidad</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Stock Mín.</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Costo</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Precio</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Ubicación</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Proveedor</string>
       </property>
      </column>
     </widget>

--- a/app/ui/ui_inventario.py
+++ b/app/ui/ui_inventario.py
@@ -15,10 +15,11 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QAbstractItemView, QApplication, QDialog, QHBoxLayout,
-    QHeaderView, QLineEdit, QPushButton, QSizePolicy,
-    QSpacerItem, QSpinBox, QTableWidget, QTableWidgetItem,
-    QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QAbstractItemView, QApplication, QComboBox, QDialog,
+    QDoubleSpinBox, QGridLayout, QHBoxLayout, QHeaderView,
+    QLineEdit, QPushButton, QSizePolicy, QSpacerItem,
+    QSpinBox, QTableWidget, QTableWidgetItem, QVBoxLayout,
+    QWidget)
 
 class Ui_InventarioDialog(object):
     def setupUi(self, InventarioDialog):
@@ -26,36 +27,91 @@ class Ui_InventarioDialog(object):
             InventarioDialog.setObjectName(u"InventarioDialog")
         self.verticalLayout = QVBoxLayout(InventarioDialog)
         self.verticalLayout.setObjectName(u"verticalLayout")
-        self.layoutInputs = QHBoxLayout()
+        self.layoutInputs = QGridLayout()
         self.layoutInputs.setObjectName(u"layoutInputs")
+        self.lineEditSKU = QLineEdit(InventarioDialog)
+        self.lineEditSKU.setObjectName(u"lineEditSKU")
+
+        self.layoutInputs.addWidget(self.lineEditSKU, 0, 0, 1, 1)
+
         self.lineEditNombre = QLineEdit(InventarioDialog)
         self.lineEditNombre.setObjectName(u"lineEditNombre")
 
-        self.layoutInputs.addWidget(self.lineEditNombre)
+        self.layoutInputs.addWidget(self.lineEditNombre, 0, 1, 1, 1)
+
+        self.comboCategoria = QComboBox(InventarioDialog)
+        self.comboCategoria.setObjectName(u"comboCategoria")
+        self.comboCategoria.setEditable(True)
+
+        self.layoutInputs.addWidget(self.comboCategoria, 0, 2, 1, 1)
 
         self.spinCantidad = QSpinBox(InventarioDialog)
         self.spinCantidad.setObjectName(u"spinCantidad")
         self.spinCantidad.setMinimum(0)
 
-        self.layoutInputs.addWidget(self.spinCantidad)
+        self.layoutInputs.addWidget(self.spinCantidad, 0, 3, 1, 1)
+
+        self.spinStockMin = QSpinBox(InventarioDialog)
+        self.spinStockMin.setObjectName(u"spinStockMin")
+        self.spinStockMin.setMinimum(0)
+
+        self.layoutInputs.addWidget(self.spinStockMin, 0, 4, 1, 1)
+
+        self.doubleCosto = QDoubleSpinBox(InventarioDialog)
+        self.doubleCosto.setObjectName(u"doubleCosto")
+        self.doubleCosto.setDecimals(2)
+        self.doubleCosto.setMinimum(0.000000000000000)
+
+        self.layoutInputs.addWidget(self.doubleCosto, 1, 0, 1, 1)
+
+        self.doublePrecio = QDoubleSpinBox(InventarioDialog)
+        self.doublePrecio.setObjectName(u"doublePrecio")
+        self.doublePrecio.setDecimals(2)
+        self.doublePrecio.setMinimum(0.000000000000000)
+
+        self.layoutInputs.addWidget(self.doublePrecio, 1, 1, 1, 1)
+
+        self.lineUbicacion = QLineEdit(InventarioDialog)
+        self.lineUbicacion.setObjectName(u"lineUbicacion")
+
+        self.layoutInputs.addWidget(self.lineUbicacion, 1, 2, 1, 1)
+
+        self.lineProveedor = QLineEdit(InventarioDialog)
+        self.lineProveedor.setObjectName(u"lineProveedor")
+
+        self.layoutInputs.addWidget(self.lineProveedor, 1, 3, 1, 1)
 
         self.btnAgregar = QPushButton(InventarioDialog)
         self.btnAgregar.setObjectName(u"btnAgregar")
 
-        self.layoutInputs.addWidget(self.btnAgregar)
+        self.layoutInputs.addWidget(self.btnAgregar, 1, 4, 1, 1)
 
 
         self.verticalLayout.addLayout(self.layoutInputs)
 
         self.tableProductos = QTableWidget(InventarioDialog)
-        if (self.tableProductos.columnCount() < 2):
-            self.tableProductos.setColumnCount(2)
+        if (self.tableProductos.columnCount() < 9):
+            self.tableProductos.setColumnCount(9)
         __qtablewidgetitem = QTableWidgetItem()
         self.tableProductos.setHorizontalHeaderItem(0, __qtablewidgetitem)
         __qtablewidgetitem1 = QTableWidgetItem()
         self.tableProductos.setHorizontalHeaderItem(1, __qtablewidgetitem1)
+        __qtablewidgetitem2 = QTableWidgetItem()
+        self.tableProductos.setHorizontalHeaderItem(2, __qtablewidgetitem2)
+        __qtablewidgetitem3 = QTableWidgetItem()
+        self.tableProductos.setHorizontalHeaderItem(3, __qtablewidgetitem3)
+        __qtablewidgetitem4 = QTableWidgetItem()
+        self.tableProductos.setHorizontalHeaderItem(4, __qtablewidgetitem4)
+        __qtablewidgetitem5 = QTableWidgetItem()
+        self.tableProductos.setHorizontalHeaderItem(5, __qtablewidgetitem5)
+        __qtablewidgetitem6 = QTableWidgetItem()
+        self.tableProductos.setHorizontalHeaderItem(6, __qtablewidgetitem6)
+        __qtablewidgetitem7 = QTableWidgetItem()
+        self.tableProductos.setHorizontalHeaderItem(7, __qtablewidgetitem7)
+        __qtablewidgetitem8 = QTableWidgetItem()
+        self.tableProductos.setHorizontalHeaderItem(8, __qtablewidgetitem8)
         self.tableProductos.setObjectName(u"tableProductos")
-        self.tableProductos.setColumnCount(2)
+        self.tableProductos.setColumnCount(9)
         self.tableProductos.setSelectionBehavior(QAbstractItemView.SelectRows)
 
         self.verticalLayout.addWidget(self.tableProductos)
@@ -89,9 +145,23 @@ class Ui_InventarioDialog(object):
         InventarioDialog.setWindowTitle(QCoreApplication.translate("InventarioDialog", u"Inventario", None))
         self.btnAgregar.setText(QCoreApplication.translate("InventarioDialog", u"Agregar", None))
         ___qtablewidgetitem = self.tableProductos.horizontalHeaderItem(0)
-        ___qtablewidgetitem.setText(QCoreApplication.translate("InventarioDialog", u"Nombre", None));
+        ___qtablewidgetitem.setText(QCoreApplication.translate("InventarioDialog", u"SKU", None));
         ___qtablewidgetitem1 = self.tableProductos.horizontalHeaderItem(1)
-        ___qtablewidgetitem1.setText(QCoreApplication.translate("InventarioDialog", u"Cantidad", None));
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("InventarioDialog", u"Nombre", None));
+        ___qtablewidgetitem2 = self.tableProductos.horizontalHeaderItem(2)
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("InventarioDialog", u"Categor\u00eda", None));
+        ___qtablewidgetitem3 = self.tableProductos.horizontalHeaderItem(3)
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("InventarioDialog", u"Cantidad", None));
+        ___qtablewidgetitem4 = self.tableProductos.horizontalHeaderItem(4)
+        ___qtablewidgetitem4.setText(QCoreApplication.translate("InventarioDialog", u"Stock M\u00edn.", None));
+        ___qtablewidgetitem5 = self.tableProductos.horizontalHeaderItem(5)
+        ___qtablewidgetitem5.setText(QCoreApplication.translate("InventarioDialog", u"Costo", None));
+        ___qtablewidgetitem6 = self.tableProductos.horizontalHeaderItem(6)
+        ___qtablewidgetitem6.setText(QCoreApplication.translate("InventarioDialog", u"Precio", None));
+        ___qtablewidgetitem7 = self.tableProductos.horizontalHeaderItem(7)
+        ___qtablewidgetitem7.setText(QCoreApplication.translate("InventarioDialog", u"Ubicaci\u00f3n", None));
+        ___qtablewidgetitem8 = self.tableProductos.horizontalHeaderItem(8)
+        ___qtablewidgetitem8.setText(QCoreApplication.translate("InventarioDialog", u"Proveedor", None));
         self.btnEliminar.setText(QCoreApplication.translate("InventarioDialog", u"Eliminar", None))
         self.btnCerrar.setText(QCoreApplication.translate("InventarioDialog", u"Cerrar", None))
     # retranslateUi

--- a/app/views/inventario_dialog.py
+++ b/app/views/inventario_dialog.py
@@ -21,59 +21,157 @@ class InventarioDialog(QDialog):
 
         self._load_products()
 
-    def _load_products(self):
+    def _clear_inputs(self) -> None:
+        self.ui.lineEditSKU.clear()
+        self.ui.lineEditNombre.clear()
+        self.ui.comboCategoria.setCurrentText("")
+        self.ui.spinCantidad.setValue(0)
+        self.ui.spinStockMin.setValue(0)
+        self.ui.doubleCosto.setValue(0.0)
+        self.ui.doublePrecio.setValue(0.0)
+        self.ui.lineUbicacion.clear()
+        self.ui.lineProveedor.clear()
+
+    def _load_products(self) -> None:
         self._updating = True
         table = self.ui.tableProductos
         table.blockSignals(True)
         table.setRowCount(0)
-        for row, (pid, nombre, cantidad) in enumerate(db.get_products()):
+        for row, (
+            pid,
+            sku,
+            nombre,
+            categoria,
+            cantidad,
+            stock_min,
+            costo,
+            precio,
+            ubicacion,
+            proveedor,
+            _notas,
+        ) in enumerate(db.listar_productos_detallado()):
             table.insertRow(row)
+            sku_item = QTableWidgetItem(sku or "")
+            sku_item.setData(Qt.UserRole, pid)
+            sku_item.setFlags(sku_item.flags() & ~Qt.ItemIsEditable)
             name_item = QTableWidgetItem(nombre)
-            name_item.setData(Qt.UserRole, pid)
             name_item.setFlags(name_item.flags() & ~Qt.ItemIsEditable)
+            cat_item = QTableWidgetItem(categoria or "")
+            cat_item.setFlags(cat_item.flags() & ~Qt.ItemIsEditable)
             qty_item = QTableWidgetItem(str(cantidad))
-            table.setItem(row, 0, name_item)
-            table.setItem(row, 1, qty_item)
+            stock_item = QTableWidgetItem(str(stock_min))
+            costo_item = QTableWidgetItem(f"{costo:.2f}")
+            precio_item = QTableWidgetItem(f"{precio:.2f}")
+            precio_item.setToolTip(f"Margen: {precio - costo:.2f}")
+            ubic_item = QTableWidgetItem(ubicacion or "")
+            prov_item = QTableWidgetItem(proveedor or "")
+            table.setItem(row, 0, sku_item)
+            table.setItem(row, 1, name_item)
+            table.setItem(row, 2, cat_item)
+            table.setItem(row, 3, qty_item)
+            table.setItem(row, 4, stock_item)
+            table.setItem(row, 5, costo_item)
+            table.setItem(row, 6, precio_item)
+            table.setItem(row, 7, ubic_item)
+            table.setItem(row, 8, prov_item)
         table.resizeColumnsToContents()
         table.blockSignals(False)
         self._updating = False
 
-    def agregar(self):
+    def agregar(self) -> None:
+        sku = self.ui.lineEditSKU.text().strip() or None
         nombre = self.ui.lineEditNombre.text().strip()
+        categoria = self.ui.comboCategoria.currentText().strip() or None
         cantidad = self.ui.spinCantidad.value()
+        stock_min = self.ui.spinStockMin.value()
+        costo = self.ui.doubleCosto.value()
+        precio = self.ui.doublePrecio.value()
+        ubicacion = self.ui.lineUbicacion.text().strip() or None
+        proveedor = self.ui.lineProveedor.text().strip() or None
+
         if not nombre:
             QMessageBox.warning(self, "Validación", "El nombre no puede estar vacío.")
             return
-        if db.add_product(nombre, cantidad) is None:
-            QMessageBox.warning(self, "Duplicado", "Ya existe un producto con ese nombre.")
+        if costo < 0 or precio < 0:
+            QMessageBox.warning(self, "Validación", "Costo y precio deben ser >= 0.")
             return
-        self.ui.lineEditNombre.clear()
-        self.ui.spinCantidad.setValue(0)
+        pid = db.add_product_ext(
+            sku,
+            nombre,
+            categoria,
+            cantidad,
+            stock_min,
+            costo,
+            precio,
+            ubicacion,
+            proveedor,
+            None,
+        )
+        if pid is None:
+            QMessageBox.warning(self, "Duplicado", "Ya existe un producto con ese SKU.")
+            return
+        self._clear_inputs()
         self._load_products()
 
-    def _item_changed(self, item):
-        if self._updating or item.column() != 1:
+    def _item_changed(self, item) -> None:
+        if self._updating:
             return
         row = item.row()
-        name_item = self.ui.tableProductos.item(row, 0)
-        pid = name_item.data(Qt.UserRole)
+        pid_item = self.ui.tableProductos.item(row, 0)
+        if not pid_item:
+            return
+        pid = pid_item.data(Qt.UserRole)
+        col = item.column()
         try:
-            cantidad = int(item.text())
-            if cantidad < 0:
-                raise ValueError
+            if col == 3:
+                val = int(item.text())
+                if val < 0:
+                    raise ValueError
+                db.update_product_ext(pid, cantidad=val)
+            elif col == 4:
+                val = int(item.text())
+                if val < 0:
+                    raise ValueError
+                db.update_product_ext(pid, stock_min=val)
+            elif col == 5:
+                val = float(item.text())
+                if val < 0:
+                    raise ValueError
+                db.update_product_ext(pid, costo=val)
+            elif col == 6:
+                val = float(item.text())
+                if val < 0:
+                    raise ValueError
+                db.update_product_ext(pid, precio=val)
+            elif col == 7:
+                db.update_product_ext(pid, ubicacion=item.text().strip() or None)
+            elif col == 8:
+                db.update_product_ext(pid, proveedor=item.text().strip() or None)
+            else:
+                return
         except ValueError:
-            QMessageBox.warning(self, "Validación", "Cantidad inválida.")
+            QMessageBox.warning(self, "Validación", "Valor inválido.")
             self._load_products()
             return
-        db.update_product(pid, quantity=cantidad)
+        if col in (5, 6):
+            costo = float(self.ui.tableProductos.item(row, 5).text())
+            precio = float(self.ui.tableProductos.item(row, 6).text())
+            self.ui.tableProductos.item(row, 6).setToolTip(f"Margen: {precio - costo:.2f}")
 
-    def eliminar(self):
+    def eliminar(self) -> None:
         row = self.ui.tableProductos.currentRow()
         if row < 0:
             QMessageBox.warning(self, "Eliminar", "Seleccione un producto.")
             return
-        name_item = self.ui.tableProductos.item(row, 0)
-        pid = name_item.data(Qt.UserRole)
-        if QMessageBox.question(self, "Confirmar", "¿Eliminar producto seleccionado?") == QMessageBox.Yes:
+        id_item = self.ui.tableProductos.item(row, 0)
+        if not id_item:
+            return
+        pid = id_item.data(Qt.UserRole)
+        if (
+            QMessageBox.question(
+                self, "Confirmar", "¿Eliminar producto seleccionado?"
+            )
+            == QMessageBox.Yes
+        ):
             db.delete_product(pid)
             self._load_products()


### PR DESCRIPTION
## Summary
- expand inventory UI with SKU, category, stock min, cost, price, location and provider
- add database helpers for extended product info and SKU/Name indexes
- support inline editing and validation in inventory dialog with margin tooltip

## Testing
- `python -m py_compile app/data/db.py app/views/inventario_dialog.py`
- `python tools/doctor.py` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d4de9619c832b874b84e353735813