### PR TITLE
feat: expand repair form with detailed fields

### DIFF
--- a/app/ui/reparaciones.ui
+++ b/app/ui/reparaciones.ui
@@ -39,23 +39,43 @@
       <widget class="QLineEdit" name="lineEditModelo"/>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="labelDescripcion">
+      <widget class="QLabel" name="labelDiagnostico">
        <property name="text">
-        <string>Descripción</string>
+        <string>Diagnóstico</string>
        </property>
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QPlainTextEdit" name="plainTextDescripcion"/>
+      <widget class="QPlainTextEdit" name="plainTextDiagnostico"/>
      </item>
      <item row="4" column="0">
+      <widget class="QLabel" name="labelAcciones">
+       <property name="text">
+        <string>Acciones</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QPlainTextEdit" name="plainTextAcciones"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelPiezas">
+       <property name="text">
+        <string>Piezas usadas</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QPlainTextEdit" name="plainTextPiezas"/>
+     </item>
+     <item row="6" column="0">
       <widget class="QLabel" name="labelEstado">
        <property name="text">
         <string>Estado</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="6" column="1">
       <widget class="QComboBox" name="comboEstado">
        <item>
         <property name="text">
@@ -67,21 +87,205 @@
          <string>Finalizada</string>
         </property>
        </item>
+       <item>
+        <property name="text">
+         <string>En curso</string>
+        </property>
+       </item>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="labelCosto">
+     <item row="7" column="0">
+      <widget class="QLabel" name="labelPrioridad">
        <property name="text">
-        <string>Costo</string>
+        <string>Prioridad</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QLineEdit" name="inputCosto">
-       <property name="placeholderText">
-        <string>0.00</string>
+     <item row="7" column="1">
+      <widget class="QComboBox" name="comboPrioridad">
+       <item>
+        <property name="text">
+         <string>Baja</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Normal</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Alta</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="labelManoObra">
+       <property name="text">
+        <string>Costo mano de obra</string>
        </property>
       </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxManoObra">
+       <property name="minimum">
+        <double>0.0</double>
+       </property>
+       <property name="maximum">
+        <double>999999999.0</double>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="labelCostoPiezas">
+       <property name="text">
+        <string>Costo piezas</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxCostoPiezas">
+       <property name="minimum">
+        <double>0.0</double>
+       </property>
+       <property name="maximum">
+        <double>999999999.0</double>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="labelDeposito">
+       <property name="text">
+        <string>Depósito</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxDeposito">
+       <property name="minimum">
+        <double>0.0</double>
+       </property>
+       <property name="maximum">
+        <double>999999999.0</double>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="labelTotal">
+       <property name="text">
+        <string>Total</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxTotal">
+       <property name="minimum">
+        <double>0.0</double>
+       </property>
+       <property name="maximum">
+        <double>999999999.0</double>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="labelSaldo">
+       <property name="text">
+        <string>Saldo</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxSaldo">
+       <property name="minimum">
+        <double>0.0</double>
+       </property>
+       <property name="maximum">
+        <double>999999999.0</double>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="13" column="0">
+      <widget class="QLabel" name="labelTecnico">
+       <property name="text">
+        <string>Técnico</string>
+       </property>
+      </widget>
+     </item>
+     <item row="13" column="1">
+      <widget class="QLineEdit" name="lineEditTecnico"/>
+     </item>
+     <item row="14" column="0">
+      <widget class="QLabel" name="labelGarantia">
+       <property name="text">
+        <string>Garantía días</string>
+       </property>
+      </widget>
+     </item>
+     <item row="14" column="1">
+      <widget class="QSpinBox" name="spinBoxGarantia">
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>9999</number>
+       </property>
+      </widget>
+     </item>
+     <item row="15" column="0">
+      <widget class="QLabel" name="labelPassBloqueo">
+       <property name="text">
+        <string>Pass bloqueo</string>
+       </property>
+      </widget>
+     </item>
+     <item row="15" column="1">
+      <widget class="QLineEdit" name="lineEditPassBloqueo">
+       <property name="echoMode">
+        <enum>QLineEdit::Password</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="16" column="0">
+      <widget class="QLabel" name="labelRespaldo">
+       <property name="text">
+        <string>Respaldo datos</string>
+       </property>
+      </widget>
+     </item>
+     <item row="16" column="1">
+      <widget class="QCheckBox" name="checkBoxRespaldo"/>
+     </item>
+     <item row="17" column="0">
+      <widget class="QLabel" name="labelAccesorios">
+       <property name="text">
+        <string>Accesorios entregados</string>
+       </property>
+      </widget>
+     </item>
+     <item row="17" column="1">
+      <widget class="QLineEdit" name="lineEditAccesorios"/>
      </item>
     </layout>
    </item>
@@ -121,3 +325,4 @@
  <resources/>
  <connections/>
 </ui>
+

--- a/app/ui/ui_reparaciones.py
+++ b/app/ui/ui_reparaciones.py
@@ -15,10 +15,10 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QFont, QFontDatabase, QGradient, QIcon,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QApplication, QComboBox, QDialog, QFormLayout,
-    QHBoxLayout, QLabel, QLineEdit, QPlainTextEdit,
-    QPushButton, QSizePolicy, QSpacerItem, QVBoxLayout,
-    QWidget)
+from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QDialog,
+    QDoubleSpinBox, QFormLayout, QHBoxLayout, QLabel,
+    QLineEdit, QPlainTextEdit, QPushButton, QSizePolicy,
+    QSpacerItem, QSpinBox, QVBoxLayout, QWidget)
 
 class Ui_ReparacionesDialog(object):
     def setupUi(self, ReparacionesDialog):
@@ -58,37 +58,181 @@ class Ui_ReparacionesDialog(object):
 
         self.formLayout.setWidget(2, QFormLayout.ItemRole.FieldRole, self.lineEditModelo)
 
-        self.labelDescripcion = QLabel(ReparacionesDialog)
-        self.labelDescripcion.setObjectName(u"labelDescripcion")
+        self.labelDiagnostico = QLabel(ReparacionesDialog)
+        self.labelDiagnostico.setObjectName(u"labelDiagnostico")
 
-        self.formLayout.setWidget(3, QFormLayout.ItemRole.LabelRole, self.labelDescripcion)
+        self.formLayout.setWidget(3, QFormLayout.ItemRole.LabelRole, self.labelDiagnostico)
 
-        self.plainTextDescripcion = QPlainTextEdit(ReparacionesDialog)
-        self.plainTextDescripcion.setObjectName(u"plainTextDescripcion")
+        self.plainTextDiagnostico = QPlainTextEdit(ReparacionesDialog)
+        self.plainTextDiagnostico.setObjectName(u"plainTextDiagnostico")
 
-        self.formLayout.setWidget(3, QFormLayout.ItemRole.FieldRole, self.plainTextDescripcion)
+        self.formLayout.setWidget(3, QFormLayout.ItemRole.FieldRole, self.plainTextDiagnostico)
+
+        self.labelAcciones = QLabel(ReparacionesDialog)
+        self.labelAcciones.setObjectName(u"labelAcciones")
+
+        self.formLayout.setWidget(4, QFormLayout.ItemRole.LabelRole, self.labelAcciones)
+
+        self.plainTextAcciones = QPlainTextEdit(ReparacionesDialog)
+        self.plainTextAcciones.setObjectName(u"plainTextAcciones")
+
+        self.formLayout.setWidget(4, QFormLayout.ItemRole.FieldRole, self.plainTextAcciones)
+
+        self.labelPiezas = QLabel(ReparacionesDialog)
+        self.labelPiezas.setObjectName(u"labelPiezas")
+
+        self.formLayout.setWidget(5, QFormLayout.ItemRole.LabelRole, self.labelPiezas)
+
+        self.plainTextPiezas = QPlainTextEdit(ReparacionesDialog)
+        self.plainTextPiezas.setObjectName(u"plainTextPiezas")
+
+        self.formLayout.setWidget(5, QFormLayout.ItemRole.FieldRole, self.plainTextPiezas)
 
         self.labelEstado = QLabel(ReparacionesDialog)
         self.labelEstado.setObjectName(u"labelEstado")
 
-        self.formLayout.setWidget(4, QFormLayout.ItemRole.LabelRole, self.labelEstado)
+        self.formLayout.setWidget(6, QFormLayout.ItemRole.LabelRole, self.labelEstado)
 
         self.comboEstado = QComboBox(ReparacionesDialog)
         self.comboEstado.addItem("")
         self.comboEstado.addItem("")
+        self.comboEstado.addItem("")
         self.comboEstado.setObjectName(u"comboEstado")
 
-        self.formLayout.setWidget(4, QFormLayout.ItemRole.FieldRole, self.comboEstado)
+        self.formLayout.setWidget(6, QFormLayout.ItemRole.FieldRole, self.comboEstado)
 
-        self.labelCosto = QLabel(ReparacionesDialog)
-        self.labelCosto.setObjectName(u"labelCosto")
+        self.labelPrioridad = QLabel(ReparacionesDialog)
+        self.labelPrioridad.setObjectName(u"labelPrioridad")
 
-        self.formLayout.setWidget(5, QFormLayout.ItemRole.LabelRole, self.labelCosto)
+        self.formLayout.setWidget(7, QFormLayout.ItemRole.LabelRole, self.labelPrioridad)
 
-        self.inputCosto = QLineEdit(ReparacionesDialog)
-        self.inputCosto.setObjectName(u"inputCosto")
+        self.comboPrioridad = QComboBox(ReparacionesDialog)
+        self.comboPrioridad.addItem("")
+        self.comboPrioridad.addItem("")
+        self.comboPrioridad.addItem("")
+        self.comboPrioridad.setObjectName(u"comboPrioridad")
 
-        self.formLayout.setWidget(5, QFormLayout.ItemRole.FieldRole, self.inputCosto)
+        self.formLayout.setWidget(7, QFormLayout.ItemRole.FieldRole, self.comboPrioridad)
+
+        self.labelManoObra = QLabel(ReparacionesDialog)
+        self.labelManoObra.setObjectName(u"labelManoObra")
+
+        self.formLayout.setWidget(8, QFormLayout.ItemRole.LabelRole, self.labelManoObra)
+
+        self.doubleSpinBoxManoObra = QDoubleSpinBox(ReparacionesDialog)
+        self.doubleSpinBoxManoObra.setObjectName(u"doubleSpinBoxManoObra")
+        self.doubleSpinBoxManoObra.setMinimum(0.000000000000000)
+        self.doubleSpinBoxManoObra.setMaximum(999999999.000000000000000)
+        self.doubleSpinBoxManoObra.setDecimals(2)
+
+        self.formLayout.setWidget(8, QFormLayout.ItemRole.FieldRole, self.doubleSpinBoxManoObra)
+
+        self.labelCostoPiezas = QLabel(ReparacionesDialog)
+        self.labelCostoPiezas.setObjectName(u"labelCostoPiezas")
+
+        self.formLayout.setWidget(9, QFormLayout.ItemRole.LabelRole, self.labelCostoPiezas)
+
+        self.doubleSpinBoxCostoPiezas = QDoubleSpinBox(ReparacionesDialog)
+        self.doubleSpinBoxCostoPiezas.setObjectName(u"doubleSpinBoxCostoPiezas")
+        self.doubleSpinBoxCostoPiezas.setMinimum(0.000000000000000)
+        self.doubleSpinBoxCostoPiezas.setMaximum(999999999.000000000000000)
+        self.doubleSpinBoxCostoPiezas.setDecimals(2)
+
+        self.formLayout.setWidget(9, QFormLayout.ItemRole.FieldRole, self.doubleSpinBoxCostoPiezas)
+
+        self.labelDeposito = QLabel(ReparacionesDialog)
+        self.labelDeposito.setObjectName(u"labelDeposito")
+
+        self.formLayout.setWidget(10, QFormLayout.ItemRole.LabelRole, self.labelDeposito)
+
+        self.doubleSpinBoxDeposito = QDoubleSpinBox(ReparacionesDialog)
+        self.doubleSpinBoxDeposito.setObjectName(u"doubleSpinBoxDeposito")
+        self.doubleSpinBoxDeposito.setMinimum(0.000000000000000)
+        self.doubleSpinBoxDeposito.setMaximum(999999999.000000000000000)
+        self.doubleSpinBoxDeposito.setDecimals(2)
+
+        self.formLayout.setWidget(10, QFormLayout.ItemRole.FieldRole, self.doubleSpinBoxDeposito)
+
+        self.labelTotal = QLabel(ReparacionesDialog)
+        self.labelTotal.setObjectName(u"labelTotal")
+
+        self.formLayout.setWidget(11, QFormLayout.ItemRole.LabelRole, self.labelTotal)
+
+        self.doubleSpinBoxTotal = QDoubleSpinBox(ReparacionesDialog)
+        self.doubleSpinBoxTotal.setObjectName(u"doubleSpinBoxTotal")
+        self.doubleSpinBoxTotal.setMinimum(0.000000000000000)
+        self.doubleSpinBoxTotal.setMaximum(999999999.000000000000000)
+        self.doubleSpinBoxTotal.setDecimals(2)
+        self.doubleSpinBoxTotal.setReadOnly(True)
+
+        self.formLayout.setWidget(11, QFormLayout.ItemRole.FieldRole, self.doubleSpinBoxTotal)
+
+        self.labelSaldo = QLabel(ReparacionesDialog)
+        self.labelSaldo.setObjectName(u"labelSaldo")
+
+        self.formLayout.setWidget(12, QFormLayout.ItemRole.LabelRole, self.labelSaldo)
+
+        self.doubleSpinBoxSaldo = QDoubleSpinBox(ReparacionesDialog)
+        self.doubleSpinBoxSaldo.setObjectName(u"doubleSpinBoxSaldo")
+        self.doubleSpinBoxSaldo.setMinimum(0.000000000000000)
+        self.doubleSpinBoxSaldo.setMaximum(999999999.000000000000000)
+        self.doubleSpinBoxSaldo.setDecimals(2)
+        self.doubleSpinBoxSaldo.setReadOnly(True)
+
+        self.formLayout.setWidget(12, QFormLayout.ItemRole.FieldRole, self.doubleSpinBoxSaldo)
+
+        self.labelTecnico = QLabel(ReparacionesDialog)
+        self.labelTecnico.setObjectName(u"labelTecnico")
+
+        self.formLayout.setWidget(13, QFormLayout.ItemRole.LabelRole, self.labelTecnico)
+
+        self.lineEditTecnico = QLineEdit(ReparacionesDialog)
+        self.lineEditTecnico.setObjectName(u"lineEditTecnico")
+
+        self.formLayout.setWidget(13, QFormLayout.ItemRole.FieldRole, self.lineEditTecnico)
+
+        self.labelGarantia = QLabel(ReparacionesDialog)
+        self.labelGarantia.setObjectName(u"labelGarantia")
+
+        self.formLayout.setWidget(14, QFormLayout.ItemRole.LabelRole, self.labelGarantia)
+
+        self.spinBoxGarantia = QSpinBox(ReparacionesDialog)
+        self.spinBoxGarantia.setObjectName(u"spinBoxGarantia")
+        self.spinBoxGarantia.setMinimum(0)
+        self.spinBoxGarantia.setMaximum(9999)
+
+        self.formLayout.setWidget(14, QFormLayout.ItemRole.FieldRole, self.spinBoxGarantia)
+
+        self.labelPassBloqueo = QLabel(ReparacionesDialog)
+        self.labelPassBloqueo.setObjectName(u"labelPassBloqueo")
+
+        self.formLayout.setWidget(15, QFormLayout.ItemRole.LabelRole, self.labelPassBloqueo)
+
+        self.lineEditPassBloqueo = QLineEdit(ReparacionesDialog)
+        self.lineEditPassBloqueo.setObjectName(u"lineEditPassBloqueo")
+        self.lineEditPassBloqueo.setEchoMode(QLineEdit.Password)
+
+        self.formLayout.setWidget(15, QFormLayout.ItemRole.FieldRole, self.lineEditPassBloqueo)
+
+        self.labelRespaldo = QLabel(ReparacionesDialog)
+        self.labelRespaldo.setObjectName(u"labelRespaldo")
+
+        self.formLayout.setWidget(16, QFormLayout.ItemRole.LabelRole, self.labelRespaldo)
+
+        self.checkBoxRespaldo = QCheckBox(ReparacionesDialog)
+        self.checkBoxRespaldo.setObjectName(u"checkBoxRespaldo")
+
+        self.formLayout.setWidget(16, QFormLayout.ItemRole.FieldRole, self.checkBoxRespaldo)
+
+        self.labelAccesorios = QLabel(ReparacionesDialog)
+        self.labelAccesorios.setObjectName(u"labelAccesorios")
+
+        self.formLayout.setWidget(17, QFormLayout.ItemRole.LabelRole, self.labelAccesorios)
+
+        self.lineEditAccesorios = QLineEdit(ReparacionesDialog)
+        self.lineEditAccesorios.setObjectName(u"lineEditAccesorios")
+
+        self.formLayout.setWidget(17, QFormLayout.ItemRole.FieldRole, self.lineEditAccesorios)
 
 
         self.verticalLayout.addLayout(self.formLayout)
@@ -123,13 +267,29 @@ class Ui_ReparacionesDialog(object):
         self.labelCliente.setText(QCoreApplication.translate("ReparacionesDialog", u"Cliente", None))
         self.labelMarca.setText(QCoreApplication.translate("ReparacionesDialog", u"Marca", None))
         self.labelModelo.setText(QCoreApplication.translate("ReparacionesDialog", u"Modelo", None))
-        self.labelDescripcion.setText(QCoreApplication.translate("ReparacionesDialog", u"Descripci\u00f3n", None))
+        self.labelDiagnostico.setText(QCoreApplication.translate("ReparacionesDialog", u"Diagn\u00f3stico", None))
+        self.labelAcciones.setText(QCoreApplication.translate("ReparacionesDialog", u"Acciones", None))
+        self.labelPiezas.setText(QCoreApplication.translate("ReparacionesDialog", u"Piezas usadas", None))
         self.labelEstado.setText(QCoreApplication.translate("ReparacionesDialog", u"Estado", None))
         self.comboEstado.setItemText(0, QCoreApplication.translate("ReparacionesDialog", u"Pendiente", None))
         self.comboEstado.setItemText(1, QCoreApplication.translate("ReparacionesDialog", u"Finalizada", None))
+        self.comboEstado.setItemText(2, QCoreApplication.translate("ReparacionesDialog", u"En curso", None))
 
-        self.labelCosto.setText(QCoreApplication.translate("ReparacionesDialog", u"Costo", None))
-        self.inputCosto.setPlaceholderText(QCoreApplication.translate("ReparacionesDialog", u"0.00", None))
+        self.labelPrioridad.setText(QCoreApplication.translate("ReparacionesDialog", u"Prioridad", None))
+        self.comboPrioridad.setItemText(0, QCoreApplication.translate("ReparacionesDialog", u"Baja", None))
+        self.comboPrioridad.setItemText(1, QCoreApplication.translate("ReparacionesDialog", u"Normal", None))
+        self.comboPrioridad.setItemText(2, QCoreApplication.translate("ReparacionesDialog", u"Alta", None))
+
+        self.labelManoObra.setText(QCoreApplication.translate("ReparacionesDialog", u"Costo mano de obra", None))
+        self.labelCostoPiezas.setText(QCoreApplication.translate("ReparacionesDialog", u"Costo piezas", None))
+        self.labelDeposito.setText(QCoreApplication.translate("ReparacionesDialog", u"Dep\u00f3sito", None))
+        self.labelTotal.setText(QCoreApplication.translate("ReparacionesDialog", u"Total", None))
+        self.labelSaldo.setText(QCoreApplication.translate("ReparacionesDialog", u"Saldo", None))
+        self.labelTecnico.setText(QCoreApplication.translate("ReparacionesDialog", u"T\u00e9cnico", None))
+        self.labelGarantia.setText(QCoreApplication.translate("ReparacionesDialog", u"Garant\u00eda d\u00edas", None))
+        self.labelPassBloqueo.setText(QCoreApplication.translate("ReparacionesDialog", u"Pass bloqueo", None))
+        self.labelRespaldo.setText(QCoreApplication.translate("ReparacionesDialog", u"Respaldo datos", None))
+        self.labelAccesorios.setText(QCoreApplication.translate("ReparacionesDialog", u"Accesorios entregados", None))
         self.btnGuardar.setText(QCoreApplication.translate("ReparacionesDialog", u"Guardar", None))
         self.btnCancelar.setText(QCoreApplication.translate("ReparacionesDialog", u"Cancelar", None))
     # retranslateUi

--- a/app/views/reparaciones_dialog.py
+++ b/app/views/reparaciones_dialog.py
@@ -11,6 +11,18 @@ class ReparacionesDialog(QDialog):
         self.ui = Ui_ReparacionesDialog()
         self.ui.setupUi(self)
 
+        # Totals are recalculated whenever related values change
+        for widget in (
+            self.ui.doubleSpinBoxManoObra,
+            self.ui.doubleSpinBoxCostoPiezas,
+            self.ui.doubleSpinBoxDeposito,
+        ):
+            widget.valueChanged.connect(self._actualizar_totales)
+
+        self.ui.doubleSpinBoxTotal.setReadOnly(True)
+        self.ui.doubleSpinBoxSaldo.setReadOnly(True)
+        self._actualizar_totales()
+
         self.ui.btnGuardar.clicked.connect(self._guardar)
         self.ui.btnCancelar.clicked.connect(self.reject)
 
@@ -18,21 +30,55 @@ class ReparacionesDialog(QDialog):
         cliente = self.ui.lineEditCliente.text().strip()
         marca = self.ui.lineEditMarca.text().strip()
         modelo = self.ui.lineEditModelo.text().strip()
-        descripcion = self.ui.plainTextDescripcion.toPlainText().strip()
+        diagnostico = self.ui.plainTextDiagnostico.toPlainText().strip()
+        acciones = self.ui.plainTextAcciones.toPlainText().strip()
+        piezas = self.ui.plainTextPiezas.toPlainText().strip()
         estado = self.ui.comboEstado.currentText()
-        costo_text = self.ui.inputCosto.text().strip()
+        prioridad = self.ui.comboPrioridad.currentText()
+        mano_obra = self.ui.doubleSpinBoxManoObra.value()
+        deposito = self.ui.doubleSpinBoxDeposito.value()
+        total = self.ui.doubleSpinBoxTotal.value()
+        saldo = self.ui.doubleSpinBoxSaldo.value()
+        tecnico = self.ui.lineEditTecnico.text().strip()
+        garantia = self.ui.spinBoxGarantia.value()
+        pass_bloqueo = self.ui.lineEditPassBloqueo.text().strip()
+        respaldo = self.ui.checkBoxRespaldo.isChecked()
+        accesorios = self.ui.lineEditAccesorios.text().strip()
 
         if not cliente or not marca or not modelo:
             QMessageBox.warning(self, "Validación", "Cliente, marca y modelo son obligatorios.")
             return
-        try:
-            costo = float(costo_text) if costo_text else 0.0
-            if costo < 0:
-                raise ValueError
-        except ValueError:
-            QMessageBox.warning(self, "Validación", "Costo inválido.")
+        if deposito > total:
+            QMessageBox.warning(self, "Validación", "El depósito no puede superar el total.")
             return
 
-        db.add_repair(cliente, marca, modelo, descripcion, costo, estado)
+        db.add_repair(
+            cliente,
+            marca,
+            modelo,
+            diagnostico,
+            acciones,
+            piezas,
+            mano_obra,
+            deposito,
+            total,
+            saldo,
+            estado,
+            prioridad,
+            tecnico,
+            garantia,
+            pass_bloqueo,
+            respaldo,
+            accesorios,
+        )
         QMessageBox.information(self, "Reparación", "Reparación guardada correctamente.")
         self.accept()
+
+    def _actualizar_totales(self):
+        mano = self.ui.doubleSpinBoxManoObra.value()
+        piezas = self.ui.doubleSpinBoxCostoPiezas.value()
+        total = mano + piezas
+        self.ui.doubleSpinBoxTotal.setValue(total)
+        deposito = self.ui.doubleSpinBoxDeposito.value()
+        saldo = max(total - deposito, 0.0)
+        self.ui.doubleSpinBoxSaldo.setValue(saldo)


### PR DESCRIPTION
## Summary
- Add extensive repair entry UI with diagnostics, costs, priority and backup info
- Auto-calc total and balance in repair dialog and validate inputs
- Persist new repair fields in database helpers

## Testing
- `make ui`
- `make doctor` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689d4f249758832ba96ea2bfd9f5b21e