### PR TITLE
Add multi-column filtering to dialogs

### DIFF
--- a/app/views/filter_proxy.py
+++ b/app/views/filter_proxy.py
@@ -1,0 +1,28 @@
+from PySide6.QtCore import QSortFilterProxyModel, Qt
+
+
+class MultiFilterProxyModel(QSortFilterProxyModel):
+    """Proxy model allowing case-insensitive contains filtering on multiple columns."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._filters: dict[int, str] = {}
+        self.setFilterCaseSensitivity(Qt.CaseInsensitive)
+
+    def setFilterForColumn(self, column: int, pattern: str) -> None:
+        self._filters[column] = pattern.lower()
+        self.invalidateFilter()
+
+    def clearFilters(self) -> None:
+        self._filters.clear()
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row: int, source_parent):  # type: ignore[override]
+        model = self.sourceModel()
+        for column, pattern in self._filters.items():
+            if pattern:
+                index = model.index(source_row, column, source_parent)
+                data = model.data(index, Qt.DisplayRole)
+                if data is None or pattern not in str(data).lower():
+                    return False
+        return True


### PR DESCRIPTION
## Summary
- add reusable `MultiFilterProxyModel` for multi-field contains filtering
- enable column-based search bars and clear button in Clients, Devices, and Inventory dialogs
- switch dialogs to `QStandardItemModel` + proxy for sortable, filterable tables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `make doctor`


------
https://chatgpt.com/codex/tasks/task_e_689d507df68c832ba9c34ddd82e19c71