### PR TITLE
Use QTableView for model-backed tables

### DIFF
--- a/app/ui/clientes.ui
+++ b/app/ui/clientes.ui
@@ -89,36 +89,13 @@
     </layout>
    </item>
    <item>
-    <widget class="QTableWidget" name="tableClientes">
-     <property name="columnCount">
-      <number>4</number>
-     </property>
+    <widget class="QTableView" name="tableClientes">
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
      </property>
-     <column>
-      <property name="text">
-       <string>ID</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Nombre</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Teléfono</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Email</string>
-      </property>
-     </column>
     </widget>
    </item>
    <item>

--- a/app/ui/dispositivos.ui
+++ b/app/ui/dispositivos.ui
@@ -39,48 +39,10 @@
     </layout>
    </item>
    <item>
-    <widget class="QTableWidget" name="tableDispositivos">
-     <property name="columnCount">
-      <number>7</number>
-     </property>
+    <widget class="QTableView" name="tableDispositivos">
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
-     <column>
-      <property name="text">
-       <string>Cliente</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Marca</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Modelo</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>IMEI</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Nº Serie</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Color</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Accesorios</string>
-      </property>
-     </column>
     </widget>
    </item>
    <item>

--- a/app/ui/inventario.ui
+++ b/app/ui/inventario.ui
@@ -71,58 +71,10 @@
     </layout>
    </item>
    <item>
-    <widget class="QTableWidget" name="tableProductos">
-     <property name="columnCount">
-      <number>9</number>
-     </property>
+    <widget class="QTableView" name="tableProductos">
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
-     <column>
-      <property name="text">
-       <string>SKU</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Nombre</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Categoría</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Cantidad</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Stock Mín.</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Costo</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Precio</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Ubicación</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Proveedor</string>
-      </property>
-     </column>
     </widget>
    </item>
    <item>

--- a/app/ui/ui_clientes.py
+++ b/app/ui/ui_clientes.py
@@ -18,7 +18,7 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
 from PySide6.QtWidgets import (QAbstractItemView, QApplication, QDialog, QFormLayout,
     QHBoxLayout, QHeaderView, QLabel, QLineEdit,
     QPlainTextEdit, QPushButton, QSizePolicy, QSpacerItem,
-    QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget)
+    QTableView, QVBoxLayout, QWidget)
 
 class Ui_ClientesDialog(object):
     def setupUi(self, ClientesDialog):
@@ -106,19 +106,8 @@ class Ui_ClientesDialog(object):
 
         self.verticalLayout.addLayout(self.horizontalLayoutBtns)
 
-        self.tableClientes = QTableWidget(ClientesDialog)
-        if (self.tableClientes.columnCount() < 4):
-            self.tableClientes.setColumnCount(4)
-        __qtablewidgetitem = QTableWidgetItem()
-        self.tableClientes.setHorizontalHeaderItem(0, __qtablewidgetitem)
-        __qtablewidgetitem1 = QTableWidgetItem()
-        self.tableClientes.setHorizontalHeaderItem(1, __qtablewidgetitem1)
-        __qtablewidgetitem2 = QTableWidgetItem()
-        self.tableClientes.setHorizontalHeaderItem(2, __qtablewidgetitem2)
-        __qtablewidgetitem3 = QTableWidgetItem()
-        self.tableClientes.setHorizontalHeaderItem(3, __qtablewidgetitem3)
+        self.tableClientes = QTableView(ClientesDialog)
         self.tableClientes.setObjectName(u"tableClientes")
-        self.tableClientes.setColumnCount(4)
         self.tableClientes.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.tableClientes.setEditTriggers(QAbstractItemView.NoEditTriggers)
 
@@ -159,14 +148,6 @@ class Ui_ClientesDialog(object):
         self.labelNotas.setText(QCoreApplication.translate("ClientesDialog", u"Notas", None))
         self.btnAgregar.setText(QCoreApplication.translate("ClientesDialog", u"Agregar", None))
         self.btnGuardar.setText(QCoreApplication.translate("ClientesDialog", u"Guardar cambios", None))
-        ___qtablewidgetitem = self.tableClientes.horizontalHeaderItem(0)
-        ___qtablewidgetitem.setText(QCoreApplication.translate("ClientesDialog", u"ID", None));
-        ___qtablewidgetitem1 = self.tableClientes.horizontalHeaderItem(1)
-        ___qtablewidgetitem1.setText(QCoreApplication.translate("ClientesDialog", u"Nombre", None));
-        ___qtablewidgetitem2 = self.tableClientes.horizontalHeaderItem(2)
-        ___qtablewidgetitem2.setText(QCoreApplication.translate("ClientesDialog", u"Tel\u00e9fono", None));
-        ___qtablewidgetitem3 = self.tableClientes.horizontalHeaderItem(3)
-        ___qtablewidgetitem3.setText(QCoreApplication.translate("ClientesDialog", u"Email", None));
         self.btnEliminar.setText(QCoreApplication.translate("ClientesDialog", u"Eliminar", None))
         self.btnCerrar.setText(QCoreApplication.translate("ClientesDialog", u"Cerrar", None))
     # retranslateUi

--- a/app/ui/ui_dispositivos.py
+++ b/app/ui/ui_dispositivos.py
@@ -17,8 +17,8 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QAbstractItemView, QApplication, QComboBox, QDialog,
     QHBoxLayout, QHeaderView, QLineEdit, QPushButton,
-    QSizePolicy, QSpacerItem, QTableWidget, QTableWidgetItem,
-    QVBoxLayout, QWidget)
+    QSizePolicy, QSpacerItem, QTableView, QVBoxLayout,
+    QWidget)
 
 class Ui_DispositivosDialog(object):
     def setupUi(self, DispositivosDialog):
@@ -71,25 +71,8 @@ class Ui_DispositivosDialog(object):
 
         self.verticalLayout.addLayout(self.layoutInputs)
 
-        self.tableDispositivos = QTableWidget(DispositivosDialog)
-        if (self.tableDispositivos.columnCount() < 7):
-            self.tableDispositivos.setColumnCount(7)
-        __qtablewidgetitem = QTableWidgetItem()
-        self.tableDispositivos.setHorizontalHeaderItem(0, __qtablewidgetitem)
-        __qtablewidgetitem1 = QTableWidgetItem()
-        self.tableDispositivos.setHorizontalHeaderItem(1, __qtablewidgetitem1)
-        __qtablewidgetitem2 = QTableWidgetItem()
-        self.tableDispositivos.setHorizontalHeaderItem(2, __qtablewidgetitem2)
-        __qtablewidgetitem3 = QTableWidgetItem()
-        self.tableDispositivos.setHorizontalHeaderItem(3, __qtablewidgetitem3)
-        __qtablewidgetitem4 = QTableWidgetItem()
-        self.tableDispositivos.setHorizontalHeaderItem(4, __qtablewidgetitem4)
-        __qtablewidgetitem5 = QTableWidgetItem()
-        self.tableDispositivos.setHorizontalHeaderItem(5, __qtablewidgetitem5)
-        __qtablewidgetitem6 = QTableWidgetItem()
-        self.tableDispositivos.setHorizontalHeaderItem(6, __qtablewidgetitem6)
+        self.tableDispositivos = QTableView(DispositivosDialog)
         self.tableDispositivos.setObjectName(u"tableDispositivos")
-        self.tableDispositivos.setColumnCount(7)
         self.tableDispositivos.setSelectionBehavior(QAbstractItemView.SelectRows)
 
         self.verticalLayout.addWidget(self.tableDispositivos)
@@ -122,20 +105,6 @@ class Ui_DispositivosDialog(object):
     def retranslateUi(self, DispositivosDialog):
         DispositivosDialog.setWindowTitle(QCoreApplication.translate("DispositivosDialog", u"Dispositivos", None))
         self.btnAgregar.setText(QCoreApplication.translate("DispositivosDialog", u"Agregar", None))
-        ___qtablewidgetitem = self.tableDispositivos.horizontalHeaderItem(0)
-        ___qtablewidgetitem.setText(QCoreApplication.translate("DispositivosDialog", u"Cliente", None));
-        ___qtablewidgetitem1 = self.tableDispositivos.horizontalHeaderItem(1)
-        ___qtablewidgetitem1.setText(QCoreApplication.translate("DispositivosDialog", u"Marca", None));
-        ___qtablewidgetitem2 = self.tableDispositivos.horizontalHeaderItem(2)
-        ___qtablewidgetitem2.setText(QCoreApplication.translate("DispositivosDialog", u"Modelo", None));
-        ___qtablewidgetitem3 = self.tableDispositivos.horizontalHeaderItem(3)
-        ___qtablewidgetitem3.setText(QCoreApplication.translate("DispositivosDialog", u"IMEI", None));
-        ___qtablewidgetitem4 = self.tableDispositivos.horizontalHeaderItem(4)
-        ___qtablewidgetitem4.setText(QCoreApplication.translate("DispositivosDialog", u"N\u00ba Serie", None));
-        ___qtablewidgetitem5 = self.tableDispositivos.horizontalHeaderItem(5)
-        ___qtablewidgetitem5.setText(QCoreApplication.translate("DispositivosDialog", u"Color", None));
-        ___qtablewidgetitem6 = self.tableDispositivos.horizontalHeaderItem(6)
-        ___qtablewidgetitem6.setText(QCoreApplication.translate("DispositivosDialog", u"Accesorios", None));
         self.btnEliminar.setText(QCoreApplication.translate("DispositivosDialog", u"Eliminar", None))
         self.btnCerrar.setText(QCoreApplication.translate("DispositivosDialog", u"Cerrar", None))
     # retranslateUi

--- a/app/ui/ui_inventario.py
+++ b/app/ui/ui_inventario.py
@@ -18,8 +18,7 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
 from PySide6.QtWidgets import (QAbstractItemView, QApplication, QComboBox, QDialog,
     QDoubleSpinBox, QGridLayout, QHBoxLayout, QHeaderView,
     QLineEdit, QPushButton, QSizePolicy, QSpacerItem,
-    QSpinBox, QTableWidget, QTableWidgetItem, QVBoxLayout,
-    QWidget)
+    QSpinBox, QTableView, QVBoxLayout, QWidget)
 
 class Ui_InventarioDialog(object):
     def setupUi(self, InventarioDialog):
@@ -89,29 +88,8 @@ class Ui_InventarioDialog(object):
 
         self.verticalLayout.addLayout(self.layoutInputs)
 
-        self.tableProductos = QTableWidget(InventarioDialog)
-        if (self.tableProductos.columnCount() < 9):
-            self.tableProductos.setColumnCount(9)
-        __qtablewidgetitem = QTableWidgetItem()
-        self.tableProductos.setHorizontalHeaderItem(0, __qtablewidgetitem)
-        __qtablewidgetitem1 = QTableWidgetItem()
-        self.tableProductos.setHorizontalHeaderItem(1, __qtablewidgetitem1)
-        __qtablewidgetitem2 = QTableWidgetItem()
-        self.tableProductos.setHorizontalHeaderItem(2, __qtablewidgetitem2)
-        __qtablewidgetitem3 = QTableWidgetItem()
-        self.tableProductos.setHorizontalHeaderItem(3, __qtablewidgetitem3)
-        __qtablewidgetitem4 = QTableWidgetItem()
-        self.tableProductos.setHorizontalHeaderItem(4, __qtablewidgetitem4)
-        __qtablewidgetitem5 = QTableWidgetItem()
-        self.tableProductos.setHorizontalHeaderItem(5, __qtablewidgetitem5)
-        __qtablewidgetitem6 = QTableWidgetItem()
-        self.tableProductos.setHorizontalHeaderItem(6, __qtablewidgetitem6)
-        __qtablewidgetitem7 = QTableWidgetItem()
-        self.tableProductos.setHorizontalHeaderItem(7, __qtablewidgetitem7)
-        __qtablewidgetitem8 = QTableWidgetItem()
-        self.tableProductos.setHorizontalHeaderItem(8, __qtablewidgetitem8)
+        self.tableProductos = QTableView(InventarioDialog)
         self.tableProductos.setObjectName(u"tableProductos")
-        self.tableProductos.setColumnCount(9)
         self.tableProductos.setSelectionBehavior(QAbstractItemView.SelectRows)
 
         self.verticalLayout.addWidget(self.tableProductos)
@@ -144,24 +122,6 @@ class Ui_InventarioDialog(object):
     def retranslateUi(self, InventarioDialog):
         InventarioDialog.setWindowTitle(QCoreApplication.translate("InventarioDialog", u"Inventario", None))
         self.btnAgregar.setText(QCoreApplication.translate("InventarioDialog", u"Agregar", None))
-        ___qtablewidgetitem = self.tableProductos.horizontalHeaderItem(0)
-        ___qtablewidgetitem.setText(QCoreApplication.translate("InventarioDialog", u"SKU", None));
-        ___qtablewidgetitem1 = self.tableProductos.horizontalHeaderItem(1)
-        ___qtablewidgetitem1.setText(QCoreApplication.translate("InventarioDialog", u"Nombre", None));
-        ___qtablewidgetitem2 = self.tableProductos.horizontalHeaderItem(2)
-        ___qtablewidgetitem2.setText(QCoreApplication.translate("InventarioDialog", u"Categor\u00eda", None));
-        ___qtablewidgetitem3 = self.tableProductos.horizontalHeaderItem(3)
-        ___qtablewidgetitem3.setText(QCoreApplication.translate("InventarioDialog", u"Cantidad", None));
-        ___qtablewidgetitem4 = self.tableProductos.horizontalHeaderItem(4)
-        ___qtablewidgetitem4.setText(QCoreApplication.translate("InventarioDialog", u"Stock M\u00edn.", None));
-        ___qtablewidgetitem5 = self.tableProductos.horizontalHeaderItem(5)
-        ___qtablewidgetitem5.setText(QCoreApplication.translate("InventarioDialog", u"Costo", None));
-        ___qtablewidgetitem6 = self.tableProductos.horizontalHeaderItem(6)
-        ___qtablewidgetitem6.setText(QCoreApplication.translate("InventarioDialog", u"Precio", None));
-        ___qtablewidgetitem7 = self.tableProductos.horizontalHeaderItem(7)
-        ___qtablewidgetitem7.setText(QCoreApplication.translate("InventarioDialog", u"Ubicaci\u00f3n", None));
-        ___qtablewidgetitem8 = self.tableProductos.horizontalHeaderItem(8)
-        ___qtablewidgetitem8.setText(QCoreApplication.translate("InventarioDialog", u"Proveedor", None));
         self.btnEliminar.setText(QCoreApplication.translate("InventarioDialog", u"Eliminar", None))
         self.btnCerrar.setText(QCoreApplication.translate("InventarioDialog", u"Cerrar", None))
     # retranslateUi


### PR DESCRIPTION
## Summary
- replace `QTableWidget` with `QTableView` in clientes, dispositivos, and inventario dialogs so `setModel` can be used without runtime errors
- regenerate compiled UI modules

## Testing
- `make ui`
- `make doctor`


------
https://chatgpt.com/codex/tasks/task_e_689d522ef65c832bb8bd7643b32c05bc