### PR TITLE
feat: dashboard on main window

### DIFF
--- a/app/ui/main_window.ui
+++ b/app/ui/main_window.ui
@@ -36,10 +36,119 @@
        <item row="3" column="0"><widget class="QLabel" name="labelReparaciones"><property name="text"><string>Reparaciones pendientes:</string></property></widget></item>
        <item row="3" column="1"><widget class="QLabel" name="label_total_reparaciones"><property name="text"><string>0</string></property></widget></item>
       </layout>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBoxAcciones">
+       <property name="title">
+        <string>Acciones rápidas</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayoutAcciones">
+        <item>
+         <widget class="QPushButton" name="btnClientes">
+          <property name="text">
+           <string>Clientes</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnDispositivos">
+          <property name="text">
+           <string>Dispositivos</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnInventario">
+          <property name="text">
+           <string>Inventario</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnNuevaReparacion">
+          <property name="text">
+           <string>Nueva reparación</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+          <widget class="QPushButton" name="btnActualizar">
+           <property name="text">
+            <string>Actualizar</string>
+           </property>
+          </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayoutTablas">
+       <item>
+        <widget class="QGroupBox" name="groupBoxLowStock">
+         <property name="title">
+          <string>Alertas de inventario (agotados o casi)</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayoutLowStock">
+          <item>
+           <widget class="QTableWidget" name="tableLowStock">
+            <column>
+             <property name="text">
+              <string>Producto</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Cantidad</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBoxRecentRepairs">
+         <property name="title">
+          <string>Últimas reparaciones</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayoutRecent">
+          <item>
+           <widget class="QTableWidget" name="tableRecentRepairs">
+            <column>
+             <property name="text">
+              <string>Fecha</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Cliente</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Dispositivo</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Estado</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Costo</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     </layout>
+    </widget>
 
   <widget class="QMenuBar" name="menubar">
    <widget class="QMenu" name="menuArchivo">
@@ -55,9 +164,10 @@
    </widget>
    <widget class="QMenu" name="menuVer">
     <property name="title"><string>&amp;Ver</string></property>
-    <addaction name="actionTemaClaro"/>
-    <addaction name="actionTemaOscuro"/>
-   </widget>
+     <addaction name="actionTemaClaro"/>
+     <addaction name="actionTemaOscuro"/>
+     <addaction name="actionActualizar"/>
+    </widget>
    <addaction name="menuArchivo"/>
    <addaction name="menuModulos"/>
    <addaction name="menuVer"/>
@@ -72,6 +182,14 @@
   <action name="actionReparaciones"><property name="text"><string>Reparaciones</string></property></action>
   <action name="actionTemaClaro"><property name="text"><string>Tema claro</string></property></action>
   <action name="actionTemaOscuro"><property name="text"><string>Tema oscuro</string></property></action>
+  <action name="actionActualizar">
+   <property name="text">
+    <string>Actualizar</string>
+   </property>
+   <property name="shortcut">
+    <string>F5</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>

--- a/app/ui/ui_main_window.py
+++ b/app/ui/ui_main_window.py
@@ -16,9 +16,10 @@ from PySide6.QtGui import (QAction, QBrush, QColor, QConicalGradient,
     QIcon, QImage, QKeySequence, QLinearGradient,
     QPainter, QPalette, QPixmap, QRadialGradient,
     QTransform)
-from PySide6.QtWidgets import (QApplication, QFormLayout, QGroupBox, QLabel,
-    QMainWindow, QMenu, QMenuBar, QSizePolicy,
-    QStatusBar, QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QApplication, QFormLayout, QGroupBox, QHBoxLayout,
+    QHeaderView, QLabel, QMainWindow, QMenu,
+    QMenuBar, QPushButton, QSizePolicy, QStatusBar,
+    QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget)
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
@@ -39,6 +40,8 @@ class Ui_MainWindow(object):
         self.actionTemaClaro.setObjectName(u"actionTemaClaro")
         self.actionTemaOscuro = QAction(MainWindow)
         self.actionTemaOscuro.setObjectName(u"actionTemaOscuro")
+        self.actionActualizar = QAction(MainWindow)
+        self.actionActualizar.setObjectName(u"actionActualizar")
         self.centralwidget = QWidget(MainWindow)
         self.centralwidget.setObjectName(u"centralwidget")
         self.verticalLayoutMain = QVBoxLayout(self.centralwidget)
@@ -95,6 +98,85 @@ class Ui_MainWindow(object):
 
         self.verticalLayoutMain.addWidget(self.groupBoxResumen)
 
+        self.groupBoxAcciones = QGroupBox(self.centralwidget)
+        self.groupBoxAcciones.setObjectName(u"groupBoxAcciones")
+        self.horizontalLayoutAcciones = QHBoxLayout(self.groupBoxAcciones)
+        self.horizontalLayoutAcciones.setObjectName(u"horizontalLayoutAcciones")
+        self.btnClientes = QPushButton(self.groupBoxAcciones)
+        self.btnClientes.setObjectName(u"btnClientes")
+
+        self.horizontalLayoutAcciones.addWidget(self.btnClientes)
+
+        self.btnDispositivos = QPushButton(self.groupBoxAcciones)
+        self.btnDispositivos.setObjectName(u"btnDispositivos")
+
+        self.horizontalLayoutAcciones.addWidget(self.btnDispositivos)
+
+        self.btnInventario = QPushButton(self.groupBoxAcciones)
+        self.btnInventario.setObjectName(u"btnInventario")
+
+        self.horizontalLayoutAcciones.addWidget(self.btnInventario)
+
+        self.btnNuevaReparacion = QPushButton(self.groupBoxAcciones)
+        self.btnNuevaReparacion.setObjectName(u"btnNuevaReparacion")
+
+        self.horizontalLayoutAcciones.addWidget(self.btnNuevaReparacion)
+
+        self.btnActualizar = QPushButton(self.groupBoxAcciones)
+        self.btnActualizar.setObjectName(u"btnActualizar")
+
+        self.horizontalLayoutAcciones.addWidget(self.btnActualizar)
+
+
+        self.verticalLayoutMain.addWidget(self.groupBoxAcciones)
+
+        self.horizontalLayoutTablas = QHBoxLayout()
+        self.horizontalLayoutTablas.setObjectName(u"horizontalLayoutTablas")
+        self.groupBoxLowStock = QGroupBox(self.centralwidget)
+        self.groupBoxLowStock.setObjectName(u"groupBoxLowStock")
+        self.verticalLayoutLowStock = QVBoxLayout(self.groupBoxLowStock)
+        self.verticalLayoutLowStock.setObjectName(u"verticalLayoutLowStock")
+        self.tableLowStock = QTableWidget(self.groupBoxLowStock)
+        if (self.tableLowStock.columnCount() < 2):
+            self.tableLowStock.setColumnCount(2)
+        __qtablewidgetitem = QTableWidgetItem()
+        self.tableLowStock.setHorizontalHeaderItem(0, __qtablewidgetitem)
+        __qtablewidgetitem1 = QTableWidgetItem()
+        self.tableLowStock.setHorizontalHeaderItem(1, __qtablewidgetitem1)
+        self.tableLowStock.setObjectName(u"tableLowStock")
+
+        self.verticalLayoutLowStock.addWidget(self.tableLowStock)
+
+
+        self.horizontalLayoutTablas.addWidget(self.groupBoxLowStock)
+
+        self.groupBoxRecentRepairs = QGroupBox(self.centralwidget)
+        self.groupBoxRecentRepairs.setObjectName(u"groupBoxRecentRepairs")
+        self.verticalLayoutRecent = QVBoxLayout(self.groupBoxRecentRepairs)
+        self.verticalLayoutRecent.setObjectName(u"verticalLayoutRecent")
+        self.tableRecentRepairs = QTableWidget(self.groupBoxRecentRepairs)
+        if (self.tableRecentRepairs.columnCount() < 5):
+            self.tableRecentRepairs.setColumnCount(5)
+        __qtablewidgetitem2 = QTableWidgetItem()
+        self.tableRecentRepairs.setHorizontalHeaderItem(0, __qtablewidgetitem2)
+        __qtablewidgetitem3 = QTableWidgetItem()
+        self.tableRecentRepairs.setHorizontalHeaderItem(1, __qtablewidgetitem3)
+        __qtablewidgetitem4 = QTableWidgetItem()
+        self.tableRecentRepairs.setHorizontalHeaderItem(2, __qtablewidgetitem4)
+        __qtablewidgetitem5 = QTableWidgetItem()
+        self.tableRecentRepairs.setHorizontalHeaderItem(3, __qtablewidgetitem5)
+        __qtablewidgetitem6 = QTableWidgetItem()
+        self.tableRecentRepairs.setHorizontalHeaderItem(4, __qtablewidgetitem6)
+        self.tableRecentRepairs.setObjectName(u"tableRecentRepairs")
+
+        self.verticalLayoutRecent.addWidget(self.tableRecentRepairs)
+
+
+        self.horizontalLayoutTablas.addWidget(self.groupBoxRecentRepairs)
+
+
+        self.verticalLayoutMain.addLayout(self.horizontalLayoutTablas)
+
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QMenuBar(MainWindow)
         self.menubar.setObjectName(u"menubar")
@@ -119,6 +201,7 @@ class Ui_MainWindow(object):
         self.menuModulos.addAction(self.actionReparaciones)
         self.menuVer.addAction(self.actionTemaClaro)
         self.menuVer.addAction(self.actionTemaOscuro)
+        self.menuVer.addAction(self.actionActualizar)
 
         self.retranslateUi(MainWindow)
 
@@ -134,6 +217,10 @@ class Ui_MainWindow(object):
         self.actionReparaciones.setText(QCoreApplication.translate("MainWindow", u"Reparaciones", None))
         self.actionTemaClaro.setText(QCoreApplication.translate("MainWindow", u"Tema claro", None))
         self.actionTemaOscuro.setText(QCoreApplication.translate("MainWindow", u"Tema oscuro", None))
+        self.actionActualizar.setText(QCoreApplication.translate("MainWindow", u"Actualizar", None))
+#if QT_CONFIG(shortcut)
+        self.actionActualizar.setShortcut(QCoreApplication.translate("MainWindow", u"F5", None))
+#endif // QT_CONFIG(shortcut)
         self.groupBoxResumen.setTitle(QCoreApplication.translate("MainWindow", u"Resumen", None))
         self.labelClientes.setText(QCoreApplication.translate("MainWindow", u"Total clientes:", None))
         self.label_total_clientes.setText(QCoreApplication.translate("MainWindow", u"0", None))
@@ -143,6 +230,28 @@ class Ui_MainWindow(object):
         self.label_total_productos.setText(QCoreApplication.translate("MainWindow", u"0", None))
         self.labelReparaciones.setText(QCoreApplication.translate("MainWindow", u"Reparaciones pendientes:", None))
         self.label_total_reparaciones.setText(QCoreApplication.translate("MainWindow", u"0", None))
+        self.groupBoxAcciones.setTitle(QCoreApplication.translate("MainWindow", u"Acciones r\u00e1pidas", None))
+        self.btnClientes.setText(QCoreApplication.translate("MainWindow", u"Clientes", None))
+        self.btnDispositivos.setText(QCoreApplication.translate("MainWindow", u"Dispositivos", None))
+        self.btnInventario.setText(QCoreApplication.translate("MainWindow", u"Inventario", None))
+        self.btnNuevaReparacion.setText(QCoreApplication.translate("MainWindow", u"Nueva reparaci\u00f3n", None))
+        self.btnActualizar.setText(QCoreApplication.translate("MainWindow", u"Actualizar", None))
+        self.groupBoxLowStock.setTitle(QCoreApplication.translate("MainWindow", u"Alertas de inventario (agotados o casi)", None))
+        ___qtablewidgetitem = self.tableLowStock.horizontalHeaderItem(0)
+        ___qtablewidgetitem.setText(QCoreApplication.translate("MainWindow", u"Producto", None));
+        ___qtablewidgetitem1 = self.tableLowStock.horizontalHeaderItem(1)
+        ___qtablewidgetitem1.setText(QCoreApplication.translate("MainWindow", u"Cantidad", None));
+        self.groupBoxRecentRepairs.setTitle(QCoreApplication.translate("MainWindow", u"\u00daltimas reparaciones", None))
+        ___qtablewidgetitem2 = self.tableRecentRepairs.horizontalHeaderItem(0)
+        ___qtablewidgetitem2.setText(QCoreApplication.translate("MainWindow", u"Fecha", None));
+        ___qtablewidgetitem3 = self.tableRecentRepairs.horizontalHeaderItem(1)
+        ___qtablewidgetitem3.setText(QCoreApplication.translate("MainWindow", u"Cliente", None));
+        ___qtablewidgetitem4 = self.tableRecentRepairs.horizontalHeaderItem(2)
+        ___qtablewidgetitem4.setText(QCoreApplication.translate("MainWindow", u"Dispositivo", None));
+        ___qtablewidgetitem5 = self.tableRecentRepairs.horizontalHeaderItem(3)
+        ___qtablewidgetitem5.setText(QCoreApplication.translate("MainWindow", u"Estado", None));
+        ___qtablewidgetitem6 = self.tableRecentRepairs.horizontalHeaderItem(4)
+        ___qtablewidgetitem6.setText(QCoreApplication.translate("MainWindow", u"Costo", None));
         self.menuArchivo.setTitle(QCoreApplication.translate("MainWindow", u"&Archivo", None))
         self.menuModulos.setTitle(QCoreApplication.translate("MainWindow", u"&M\u00f3dulos", None))
         self.menuVer.setTitle(QCoreApplication.translate("MainWindow", u"&Ver", None))


### PR DESCRIPTION
## Summary
- expand main window UI with quick actions, low-stock alerts, and recent repairs tables
- load dashboard data from SQLite helpers with refresh support
- extend SQLite helpers with counts, low stock and recent repairs, plus repair date tracking

## Testing
- `pip install -r requirements.txt`
- `pyside6-uic app/ui/main_window.ui -o app/ui/ui_main_window.py`
- `QT_QPA_PLATFORM=offscreen timeout 5s python main.py`

------
https://chatgpt.com/codex/tasks/task_e_689d5b294b7c832babc834e1e05c4e47