### PR TITLE
Avoid adding duplicate clients

### DIFF
--- a/app/data/db.py
+++ b/app/data/db.py
@@ -278,7 +278,10 @@ def add_cliente(
     direccion: Optional[str] = None,
     nif: Optional[str] = None,
     notas: Optional[str] = None,
-) -> int:
+) -> Optional[int]:
+    existing_id = find_client_by_name(nombre)
+    if existing_id is not None:
+        return None
     conn = _ensure_conn()
     cur = conn.cursor()
     cur.execute(

--- a/app/views/clientes_dialog.py
+++ b/app/views/clientes_dialog.py
@@ -153,7 +153,7 @@ class ClientesDialog(QDialog):
             return
         self._set_error(self.ui.lineEditTelefono, False)
 
-        db.add_cliente(
+        cid = db.add_cliente(
             nombre,
             telefono=telefono or None,
             email=email or None,
@@ -161,6 +161,9 @@ class ClientesDialog(QDialog):
             nif=nif or None,
             notas=notas or None,
         )
+        if cid is None:
+            QMessageBox.warning(self, "Agregar", "El cliente ya existe.")
+            return
         self._clear_form()
         self._load_clientes()
         self._show_status("Cliente agregado")


### PR DESCRIPTION
## Summary
- Prevent adding a client with an existing name by checking before insertion
- Warn user when attempting to add a duplicate client in dialog

## Testing
- `python tools/doctor.py`


------
https://chatgpt.com/codex/tasks/task_e_689d6063957c832b8bd604b6c1fe0f5d