### PR TITLE
refactor: centralize dialog utilities

### DIFF
--- a/app/views/base_dialog.py
+++ b/app/views/base_dialog.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from PySide6.QtWidgets import (
+    QDialog,
+    QLineEdit,
+    QPushButton,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+)
+from PySide6.QtGui import QIcon
+
+
+class BaseDialog(QDialog):
+    """Diálogo base con utilidades comunes."""
+
+    def _set_button_icon(self, btn: QPushButton, resource: str) -> None:
+        icon = QIcon(resource)
+        if not icon.isNull():
+            btn.setIcon(icon)
+
+    def _show_status(self, text: str) -> None:
+        parent = self.parent()
+        if isinstance(parent, QMainWindow):
+            parent.statusBar().showMessage(text, 3000)
+
+    def _set_error(self, widget: QLineEdit, state: bool) -> None:
+        widget.setProperty("error", state)
+        widget.style().unpolish(widget)
+        widget.style().polish(widget)
+
+    def _build_filters(self, layout, specs, insert_index: int) -> None:
+        """Create a row of filter widgets.
+
+        Args:
+            layout: Layout where the filter row will be inserted.
+            specs: Iterable of (label, column) pairs.
+            insert_index: Position to insert the filter row.
+        """
+        self._filter_widgets: list[QLineEdit] = []
+        row = QHBoxLayout()
+        for label, column in specs:
+            edit = QLineEdit(self)
+            row.addWidget(QLabel(f"{label}:"))
+            row.addWidget(edit)
+            edit.textChanged.connect(lambda text, col=column: self.proxy.setFilterForColumn(col, text))
+            self._filter_widgets.append(edit)
+        btn_clear = QPushButton("Limpiar filtros", self)
+        row.addWidget(btn_clear)
+        btn_clear.clicked.connect(self._clear_filters)
+        layout.insertLayout(insert_index, row)
+
+    def _clear_filters(self) -> None:
+        for edit in getattr(self, "_filter_widgets", []):
+            edit.clear()
+        self.proxy.clearFilters()

--- a/app/views/clientes_dialog.py
+++ b/app/views/clientes_dialog.py
@@ -1,13 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide6.QtWidgets import (
-    QDialog,
-    QMessageBox,
-    QLineEdit,
-    QPushButton,
-    QHBoxLayout,
-    QLabel,
-    QMainWindow,
-)
+from PySide6.QtWidgets import QMessageBox
 from PySide6.QtGui import QRegularExpressionValidator, QStandardItemModel, QStandardItem, QIcon
 from PySide6.QtCore import QRegularExpression, Qt
 
@@ -16,9 +8,10 @@ from app.resources import icons_rc  # noqa: F401
 from app.ui.ui_clientes import Ui_ClientesDialog
 from app.data import db
 from .filter_proxy import MultiFilterProxyModel
+from .base_dialog import BaseDialog
 
 
-class ClientesDialog(QDialog):
+class ClientesDialog(BaseDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.ui = Ui_ClientesDialog()
@@ -51,53 +44,15 @@ class ClientesDialog(QDialog):
             lambda *_: self.cargar_seleccion()
         )
 
-        self._setup_filters()
+        self._build_filters(
+            self.ui.verticalLayout,
+            [("Nombre", 1), ("Teléfono", 2), ("Email", 3)],
+            2,
+        )
 
         self._clientes = {}
         self._load_clientes()
 
-    def _set_button_icon(self, btn: QPushButton, resource: str) -> None:
-        icon = QIcon(resource)
-        if not icon.isNull():
-            btn.setIcon(icon)
-
-    def _show_status(self, text: str) -> None:
-        parent = self.parent()
-        if isinstance(parent, QMainWindow):
-            parent.statusBar().showMessage(text, 3000)
-
-    def _set_error(self, widget: QLineEdit, state: bool) -> None:
-        widget.setProperty("error", state)
-        widget.style().unpolish(widget)
-        widget.style().polish(widget)
-
-    def _setup_filters(self) -> None:
-        layout = QHBoxLayout()
-        self.filter_name = QLineEdit(self)
-        self.filter_phone = QLineEdit(self)
-        self.filter_email = QLineEdit(self)
-        self.btn_clear = QPushButton("Limpiar filtros", self)
-
-        layout.addWidget(QLabel("Nombre:"))
-        layout.addWidget(self.filter_name)
-        layout.addWidget(QLabel("Teléfono:"))
-        layout.addWidget(self.filter_phone)
-        layout.addWidget(QLabel("Email:"))
-        layout.addWidget(self.filter_email)
-        layout.addWidget(self.btn_clear)
-
-        self.ui.verticalLayout.insertLayout(2, layout)
-
-        self.filter_name.textChanged.connect(lambda text: self.proxy.setFilterForColumn(1, text))
-        self.filter_phone.textChanged.connect(lambda text: self.proxy.setFilterForColumn(2, text))
-        self.filter_email.textChanged.connect(lambda text: self.proxy.setFilterForColumn(3, text))
-        self.btn_clear.clicked.connect(self._clear_filters)
-
-    def _clear_filters(self) -> None:
-        self.filter_name.clear()
-        self.filter_phone.clear()
-        self.filter_email.clear()
-        self.proxy.clearFilters()
 
     def _load_clientes(self) -> None:
         self.model.setRowCount(0)

--- a/app/views/dispositivos_dialog.py
+++ b/app/views/dispositivos_dialog.py
@@ -1,13 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide6.QtWidgets import (
-    QDialog,
-    QMessageBox,
-    QLineEdit,
-    QPushButton,
-    QHBoxLayout,
-    QLabel,
-    QMainWindow,
-)
+from PySide6.QtWidgets import QMessageBox
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QIcon
 from PySide6.QtCore import Qt
 
@@ -16,9 +8,10 @@ from app.resources import icons_rc  # noqa: F401
 from app.ui.ui_dispositivos import Ui_DispositivosDialog
 from app.data import db
 from .filter_proxy import MultiFilterProxyModel
+from .base_dialog import BaseDialog
 
 
-class DispositivosDialog(QDialog):
+class DispositivosDialog(BaseDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.ui = Ui_DispositivosDialog()
@@ -53,64 +46,20 @@ class DispositivosDialog(QDialog):
         self.ui.tableDispositivos.setModel(self.proxy)
         self.ui.tableDispositivos.setSortingEnabled(True)
 
-        self._setup_filters()
+        self._build_filters(
+            self.ui.verticalLayout,
+            [("Cliente", 0), ("Marca", 1), ("Modelo", 2), ("IMEI", 3)],
+            1,
+        )
 
         self._load_clientes()
         self._load_dispositivos()
-
-    def _set_button_icon(self, btn: QPushButton, resource: str) -> None:
-        icon = QIcon(resource)
-        if not icon.isNull():
-            btn.setIcon(icon)
-
-    def _show_status(self, text: str) -> None:
-        parent = self.parent()
-        if isinstance(parent, QMainWindow):
-            parent.statusBar().showMessage(text, 3000)
-
-    def _set_error(self, widget: QLineEdit, state: bool) -> None:
-        widget.setProperty("error", state)
-        widget.style().unpolish(widget)
-        widget.style().polish(widget)
 
     def _load_clientes(self):
         combo = self.ui.comboCliente
         combo.clear()
         for cid, nombre in db.listar_clientes():
             combo.addItem(nombre, cid)
-
-    def _setup_filters(self) -> None:
-        layout = QHBoxLayout()
-        self.filter_cliente = QLineEdit(self)
-        self.filter_marca = QLineEdit(self)
-        self.filter_modelo = QLineEdit(self)
-        self.filter_imei = QLineEdit(self)
-        self.btn_clear = QPushButton("Limpiar filtros", self)
-
-        layout.addWidget(QLabel("Cliente:"))
-        layout.addWidget(self.filter_cliente)
-        layout.addWidget(QLabel("Marca:"))
-        layout.addWidget(self.filter_marca)
-        layout.addWidget(QLabel("Modelo:"))
-        layout.addWidget(self.filter_modelo)
-        layout.addWidget(QLabel("IMEI:"))
-        layout.addWidget(self.filter_imei)
-        layout.addWidget(self.btn_clear)
-
-        self.ui.verticalLayout.insertLayout(1, layout)
-
-        self.filter_cliente.textChanged.connect(lambda text: self.proxy.setFilterForColumn(0, text))
-        self.filter_marca.textChanged.connect(lambda text: self.proxy.setFilterForColumn(1, text))
-        self.filter_modelo.textChanged.connect(lambda text: self.proxy.setFilterForColumn(2, text))
-        self.filter_imei.textChanged.connect(lambda text: self.proxy.setFilterForColumn(3, text))
-        self.btn_clear.clicked.connect(self._clear_filters)
-
-    def _clear_filters(self) -> None:
-        self.filter_cliente.clear()
-        self.filter_marca.clear()
-        self.filter_modelo.clear()
-        self.filter_imei.clear()
-        self.proxy.clearFilters()
 
     def _load_dispositivos(self):
         self._updating = True

--- a/app/views/inventario_dialog.py
+++ b/app/views/inventario_dialog.py
@@ -1,13 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide6.QtWidgets import (
-    QDialog,
-    QMessageBox,
-    QLineEdit,
-    QPushButton,
-    QHBoxLayout,
-    QLabel,
-    QMainWindow,
-)
+from PySide6.QtWidgets import QMessageBox
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QIcon
 from PySide6.QtCore import Qt
 
@@ -16,9 +8,10 @@ from app.resources import icons_rc  # noqa: F401
 from app.ui.ui_inventario import Ui_InventarioDialog
 from app.data import db
 from .filter_proxy import MultiFilterProxyModel
+from .base_dialog import BaseDialog
 
 
-class InventarioDialog(QDialog):
+class InventarioDialog(BaseDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.ui = Ui_InventarioDialog()
@@ -56,24 +49,13 @@ class InventarioDialog(QDialog):
         self.ui.tableProductos.setModel(self.proxy)
         self.ui.tableProductos.setSortingEnabled(True)
 
-        self._setup_filters()
+        self._build_filters(
+            self.ui.verticalLayout,
+            [("Nombre", 1), ("SKU", 0), ("Categoría", 2), ("Proveedor", 8)],
+            1,
+        )
 
         self._load_products()
-
-    def _set_button_icon(self, btn: QPushButton, resource: str) -> None:
-        icon = QIcon(resource)
-        if not icon.isNull():
-            btn.setIcon(icon)
-
-    def _show_status(self, text: str) -> None:
-        parent = self.parent()
-        if isinstance(parent, QMainWindow):
-            parent.statusBar().showMessage(text, 3000)
-
-    def _set_error(self, widget: QLineEdit, state: bool) -> None:
-        widget.setProperty("error", state)
-        widget.style().unpolish(widget)
-        widget.style().polish(widget)
 
     def _clear_inputs(self) -> None:
         self.ui.lineEditSKU.clear()
@@ -86,38 +68,6 @@ class InventarioDialog(QDialog):
         self.ui.lineUbicacion.clear()
         self.ui.lineProveedor.clear()
 
-    def _setup_filters(self) -> None:
-        layout = QHBoxLayout()
-        self.filter_nombre = QLineEdit(self)
-        self.filter_sku = QLineEdit(self)
-        self.filter_categoria = QLineEdit(self)
-        self.filter_proveedor = QLineEdit(self)
-        self.btn_clear = QPushButton("Limpiar filtros", self)
-
-        layout.addWidget(QLabel("Nombre:"))
-        layout.addWidget(self.filter_nombre)
-        layout.addWidget(QLabel("SKU:"))
-        layout.addWidget(self.filter_sku)
-        layout.addWidget(QLabel("Categoría:"))
-        layout.addWidget(self.filter_categoria)
-        layout.addWidget(QLabel("Proveedor:"))
-        layout.addWidget(self.filter_proveedor)
-        layout.addWidget(self.btn_clear)
-
-        self.ui.verticalLayout.insertLayout(1, layout)
-
-        self.filter_nombre.textChanged.connect(lambda text: self.proxy.setFilterForColumn(1, text))
-        self.filter_sku.textChanged.connect(lambda text: self.proxy.setFilterForColumn(0, text))
-        self.filter_categoria.textChanged.connect(lambda text: self.proxy.setFilterForColumn(2, text))
-        self.filter_proveedor.textChanged.connect(lambda text: self.proxy.setFilterForColumn(8, text))
-        self.btn_clear.clicked.connect(self._clear_filters)
-
-    def _clear_filters(self) -> None:
-        self.filter_nombre.clear()
-        self.filter_sku.clear()
-        self.filter_categoria.clear()
-        self.filter_proveedor.clear()
-        self.proxy.clearFilters()
 
     def _load_products(self) -> None:
         self._updating = True


### PR DESCRIPTION
## Summary
- add reusable `BaseDialog` with shared helpers and filter builder
- refactor ClientesDialog, DispositivosDialog and InventarioDialog to inherit from BaseDialog

## Testing
- `python tools/doctor.py`


------
https://chatgpt.com/codex/tasks/task_e_689d61caccac832bb9f9a04427713a3a