### PR TITLE
Restringe validaciones de teléfono y email

### DIFF
--- a/app/views/clientes_dialog.py
+++ b/app/views/clientes_dialog.py
@@ -23,8 +23,8 @@ class ClientesDialog(BaseDialog):
         self._set_button_icon(self.ui.btnEliminar, ":/icons/exit.svg")
         self._set_button_icon(self.ui.btnCerrar, ":/icons/exit.svg")
 
-        phone_regex = QRegularExpression(r"^$|[0-9 +]+$")
-        email_regex = QRegularExpression(r"^$|[^@\s]+@[^@\s]+\.[^@\s]+$")
+        phone_regex = QRegularExpression(r"^[0-9 +]*$")
+        email_regex = QRegularExpression(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
         self.ui.lineEditTelefono.setValidator(QRegularExpressionValidator(phone_regex, self))
         self.ui.lineEditEmail.setValidator(QRegularExpressionValidator(email_regex, self))
 


### PR DESCRIPTION
## Summary
- Restringe `lineEditTelefono` para aceptar solo dígitos, espacios o `+`
- Valida que `lineEditEmail` contenga un correo electrónico completo

## Testing
- `python -m pytest`
- `python tools/doctor.py`


------
https://chatgpt.com/codex/tasks/task_e_689ee45d2840832b86462324538f16e4