### PR TITLE
Create SKU index during migration

### DIFF
--- a/app/data/db.py
+++ b/app/data/db.py
@@ -83,10 +83,6 @@ def _create_tables(conn: sqlite3.Connection) -> None:
     except sqlite3.OperationalError:
         pass
     try:
-        cur.execute("CREATE INDEX IF NOT EXISTS idx_inventario_sku ON inventario(sku)")
-    except sqlite3.OperationalError:
-        pass
-    try:
         cur.execute("CREATE INDEX IF NOT EXISTS idx_reparaciones_estado ON reparaciones(estado)")
     except sqlite3.OperationalError:
         pass
@@ -160,6 +156,12 @@ def migrate_if_needed(conn: sqlite3.Connection) -> None:
                 cur.execute(f"ALTER TABLE inventario ADD COLUMN {column}")
             except sqlite3.OperationalError:
                 pass
+        try:
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_inventario_sku ON inventario(sku)"
+            )
+        except sqlite3.OperationalError:
+            pass
         cur.execute("UPDATE meta SET schema_version = 4")
         conn.commit()
         version = 4


### PR DESCRIPTION
## Summary
- Ensure SKU index is created when migrating to schema version 4
- Avoid creating SKU index during initial table setup before column exists

## Testing
- `python -m py_compile app/data/db.py`


------
https://chatgpt.com/codex/tasks/task_e_689ee73b41bc832baff3434aae693294