### PR TITLE
Ensure deterministic dialog variant resolution

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -54,7 +54,11 @@ class MainWindow(QMainWindow):
 
     def _load_dialog_class(self, base: str, class_name: str) -> Optional[Type[QDialog]]:
         """Try to import a dialog class handling plural/singular variations."""
-        for variant in {base, base.rstrip('s'), base + 's'}:
+        variants = [base, base.rstrip('s')]
+        if not base.endswith('s'):
+            variants.append(base + 's')
+        variants = list(dict.fromkeys(variants))
+        for variant in variants:
             module_name = f'app.views.{variant}_dialog'
             try:
                 module = importlib.import_module(module_name)


### PR DESCRIPTION
## Summary
- Ensure dialog lookup variants are evaluated in a predictable order
- Skip plural variant when the base already ends with 's'

## Testing
- `python tools/doctor.py`


------
https://chatgpt.com/codex/tasks/task_e_689ee80d4788832b8c03a5d75d5cd3e9