### PR TITLE
Close database connection on app exit

### DIFF
--- a/app/data/db.py
+++ b/app/data/db.py
@@ -14,6 +14,14 @@ def _ensure_conn() -> sqlite3.Connection:
         _create_tables(_conn)
     return _conn
 
+
+def close_db() -> None:
+    """Close the global database connection if it exists."""
+    global _conn
+    if _conn is not None:
+        _conn.close()
+        _conn = None
+
 def _create_tables(conn: sqlite3.Connection) -> None:
     cur = conn.cursor()
     # Tablas mínimas

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ def load_stylesheet(path: Path) -> str:
 def main():
     QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
     app = QApplication(sys.argv)
+    app.aboutToQuit.connect(db.close_db)
 
     settings = QSettings("galdotech", "app_mateo")
     theme = settings.value("ui/theme", "light")


### PR DESCRIPTION
## Summary
- add close_db helper to cleanly close SQLite connection
- hook QApplication.aboutToQuit to call db.close_db

## Testing
- `make doctor`
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
import sys
from PySide6.QtCore import QTimer, Qt
from PySide6.QtWidgets import QApplication
from pathlib import Path
from app.views.main_window import MainWindow
from app.data import db
import main
from PySide6.QtCore import QSettings

QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
app = QApplication(sys.argv)
app.aboutToQuit.connect(db.close_db)

settings = QSettings("galdotech", "app_mateo")
theme = settings.value("ui/theme", "light")
qss_path = Path(__file__).resolve().parent / "app" / "resources" / f"theme_{theme}.qss"
app.setStyleSheet(main.load_stylesheet(qss_path))

db.init_db()
win = MainWindow(settings)
win.show()

QTimer.singleShot(100, app.quit)
app.exec()
PY`
- `lsof app/inventario_app.db`

------
https://chatgpt.com/codex/tasks/task_e_689eee53bd30832b9b5078dc443f919b