### PR TITLE
Improve dialog import error handling

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 from pathlib import Path
 from typing import Optional, Type
 
@@ -12,6 +13,8 @@ from PySide6.QtCore import QSettings, Qt
 from app.resources import icons_rc  # noqa: F401
 from app.ui.ui_main_window import Ui_MainWindow
 from app.data import db
+
+logger = logging.getLogger(__name__)
 
 
 class MainWindow(QMainWindow):
@@ -63,8 +66,11 @@ class MainWindow(QMainWindow):
             try:
                 module = importlib.import_module(module_name)
                 return getattr(module, class_name)
-            except Exception:
+            except ImportError:
                 continue
+            except Exception:
+                logger.exception("Error loading %s from %s", class_name, module_name)
+                raise
         return None
 
     def _open_clientes(self):


### PR DESCRIPTION
## Summary
- replace broad exception handler in dialog loader with ImportError to surface internal module issues
- log unexpected exceptions during dialog import

## Testing
- `python tools/doctor.py`
- `python - <<'PY'
from app.views.main_window import MainWindow
result = MainWindow._load_dialog_class(None, 'clientes', 'ClientesDialog')
print(result)
PY`
- `python - <<'PY'
from app.views.main_window import MainWindow
print(MainWindow._load_dialog_class(None, 'foo', 'FooDialog'))
PY`
- `python - <<'PY'
from app.views.main_window import MainWindow
try:
    MainWindow._load_dialog_class(None, 'broken', 'BrokenDialog')
except Exception as e:
    print(type(e).__name__, e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689eef8f99b8832baa6c138a58c52e12