### PR TITLE
Add login dialog and role-based access control

### DIFF
--- a/app/views/login_dialog.py
+++ b/app/views/login_dialog.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+)
+
+from app.data import db
+
+
+class LoginDialog(QDialog):
+    """Simple login dialog."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Inicio de sesión")
+        layout = QVBoxLayout(self)
+
+        layout.addWidget(QLabel("Usuario:"))
+        self.edit_user = QLineEdit(self)
+        layout.addWidget(self.edit_user)
+
+        layout.addWidget(QLabel("Contraseña:"))
+        self.edit_pass = QLineEdit(self)
+        self.edit_pass.setEchoMode(QLineEdit.Password)
+        layout.addWidget(self.edit_pass)
+
+        btns = QHBoxLayout()
+        btn_login = QPushButton("Entrar", self)
+        btn_cancel = QPushButton("Cancelar", self)
+        btns.addWidget(btn_login)
+        btns.addWidget(btn_cancel)
+        layout.addLayout(btns)
+
+        btn_login.clicked.connect(self._do_login)
+        btn_cancel.clicked.connect(self.reject)
+
+        self.user_role: str | None = None
+
+    def _do_login(self) -> None:
+        nombre = self.edit_user.text().strip()
+        password = self.edit_pass.text()
+        if not nombre or not password:
+            QMessageBox.warning(self, "Login", "Ingrese usuario y contraseña.")
+            return
+        user = db.get_usuario(nombre)
+        if user is None:
+            QMessageBox.warning(self, "Login", "Usuario no encontrado.")
+            return
+        _, password_hash, rol = user
+        if db.hash_password(password) != password_hash:
+            QMessageBox.warning(self, "Login", "Contraseña incorrecta.")
+            return
+        self.user_role = rol
+        self.accept()

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -18,9 +18,10 @@ logger = logging.getLogger(__name__)
 
 
 class MainWindow(QMainWindow):
-    def __init__(self, settings: QSettings):
+    def __init__(self, settings: QSettings, user_role: str):
         super().__init__()
         self.settings = settings
+        self.user_role = user_role
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
 
@@ -52,8 +53,26 @@ class MainWindow(QMainWindow):
         self.ui.btnNuevaReparacion.clicked.connect(self._open_reparaciones)
         self.ui.btnActualizar.clicked.connect(self.refresh_all)
 
+        # Permisos según rol
+        self._apply_role_permissions()
+
         # Resumen inicial
         self.refresh_all()
+
+    def _apply_role_permissions(self) -> None:
+        if self.user_role != "admin":
+            for action in [
+                self.ui.actionClientes,
+                self.ui.actionDispositivos,
+                self.ui.actionInventario,
+            ]:
+                action.setEnabled(False)
+            for btn in [
+                self.ui.btnClientes,
+                self.ui.btnDispositivos,
+                self.ui.btnInventario,
+            ]:
+                btn.setEnabled(False)
 
     def _load_dialog_class(self, base: str, class_name: str) -> Optional[Type[QDialog]]:
         """Try to import a dialog class handling plural/singular variations."""

--- a/main.py
+++ b/main.py
@@ -3,9 +3,10 @@ import sys
 from pathlib import Path
 
 from PySide6.QtCore import Qt, QSettings
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QDialog
 
 from app.views.main_window import MainWindow
+from app.views.login_dialog import LoginDialog
 from app.data import db
 
 
@@ -31,7 +32,11 @@ def main():
     # Inicializa BD (lazy-safe: crea si no existe)
     db.init_db()
 
-    win = MainWindow(settings)
+    login = LoginDialog()
+    if login.exec() != QDialog.Accepted:
+        sys.exit(0)
+
+    win = MainWindow(settings, login.user_role or "")
     win.show()
     sys.exit(app.exec())
 


### PR DESCRIPTION
## Summary
- add usuarios table with hashed passwords and migration
- introduce login dialog and require login before opening the app
- disable client, device and inventory sections for non-admin users

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689ef69a2240832bb7949e2e2bbf3922