### PR TITLE
Validate allowed tables before export

### DIFF
--- a/app/data/export_service.py
+++ b/app/data/export_service.py
@@ -8,8 +8,19 @@ from typing import List, Tuple
 from . import db
 
 
+ALLOWED_TABLES = (
+    "clientes",
+    "dispositivos",
+    "inventario",
+    "reparaciones",
+    "usuarios",
+)
+
+
 def _fetch_table(table: str) -> Tuple[List[str], List[Tuple]]:
     """Return column names and all rows for the given table."""
+    if table not in ALLOWED_TABLES:
+        raise ValueError(f"Invalid table name: {table}")
     conn = db._ensure_conn()
     cur = conn.cursor()
     cur.execute(f"SELECT * FROM {table}")


### PR DESCRIPTION
## Summary
- restrict exported tables to known list before querying

## Testing
- `python -m pytest`
- `python tools/doctor.py` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f023f069c832ba859ec17d815e36a