### PR TITLE
Type counts in summary service

### DIFF
--- a/app/data/summary_service.py
+++ b/app/data/summary_service.py
@@ -1,6 +1,8 @@
 """Summary service for dashboard counts."""
 from __future__ import annotations
 
+from typing import cast
+
 from app.data import db
 
 
@@ -11,7 +13,7 @@ def get_counts() -> tuple[int, int, int, int]:
         tuple: (total_clientes, total_dispositivos, total_productos, total_reparaciones_pendientes)
         If an error occurs when retrieving a count, the affected value will be ``0``.
     """
-    counts = []
+    counts: list[int] = []
     funcs = (
         db.contar_clientes,
         db.contar_dispositivos,
@@ -23,4 +25,5 @@ def get_counts() -> tuple[int, int, int, int]:
             counts.append(func())
         except Exception:
             counts.append(0)
-    return tuple(counts)  # type: ignore[return-value]
+
+    return cast(tuple[int, int, int, int], tuple(counts))


### PR DESCRIPTION
## Summary
- type counts variable in summary service
- cast count tuple to satisfy return type

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f034638b4832bb321e90d50314bb1