### PR TITLE
Ensure database reinitialization resets connection

### DIFF
--- a/app/data/db.py
+++ b/app/data/db.py
@@ -266,6 +266,8 @@ def migrate_if_needed(conn: sqlite3.Connection) -> None:
 # API pública
 def init_db(path: str = DB_PATH) -> None:
     global DB_PATH
+    if _conn is not None:
+        close_db()
     DB_PATH = path
     conn = _ensure_conn()
     _ensure_stock_min_column(conn)

--- a/tests/test_init_db.py
+++ b/tests/test_init_db.py
@@ -1,0 +1,29 @@
+import os
+import sqlite3
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.data import db
+
+
+def test_init_db_switches_connection(tmp_path):
+    path1 = tmp_path / "first.db"
+    path2 = tmp_path / "second.db"
+
+    db.init_db(str(path1))
+    conn1 = db._ensure_conn()
+
+    db.init_db(str(path2))
+    conn2 = db._ensure_conn()
+
+    assert db.DB_PATH == str(path2)
+    assert conn1 is not conn2
+    db_path = conn2.execute("PRAGMA database_list").fetchone()[2]
+    assert db_path == str(path2)
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        conn1.execute("SELECT 1")
+
+    db.close_db()


### PR DESCRIPTION
## Summary
- close previous database connection when reinitializing with a new path
- add tests verifying init_db reconnects to the provided path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f03e87b38832bba342b27a75a430e