### PR TITLE
Implement salted password hashing for users

### DIFF
--- a/app/views/login_dialog.py
+++ b/app/views/login_dialog.py
@@ -51,8 +51,8 @@ class LoginDialog(QDialog):
         if user is None:
             QMessageBox.warning(self, "Login", "Usuario no encontrado.")
             return
-        _, password_hash, rol = user
-        if db.hash_password(password) != password_hash:
+        _, password_hash, salt, rol = user
+        if not db.verify_password(password, password_hash, salt):
             QMessageBox.warning(self, "Login", "Contraseña incorrecta.")
             return
         self.user_role = rol


### PR DESCRIPTION
## Summary
- Use PBKDF2 with per-user salt for password hashing and verification
- Expand usuarios table with `password_hash` and `salt` columns, migrating existing entries
- Update login dialog to validate passwords with the new salted scheme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0682089c832b839582a31cd45798