### PR TITLE
Centralize dashboard summary service and tests

### DIFF
--- a/app/data/db.py
+++ b/app/data/db.py
@@ -329,17 +329,6 @@ def contar_reparaciones_pendientes() -> int:
     cur.execute("SELECT COUNT(*) FROM reparaciones WHERE estado = 'Pendiente'")
     return cur.fetchone()[0]
 
-
-def get_counts() -> Tuple[int, int, int, int]:
-    """Return total counts for dashboard."""
-    return (
-        contar_clientes(),
-        contar_dispositivos(),
-        contar_productos(),
-        contar_reparaciones_pendientes(),
-    )
-
-
 def get_low_stock_products(limit: int = 8) -> List[Tuple[str, int, int]]:
     cur = _ensure_conn().cursor()
     cur.execute(

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -19,7 +19,7 @@ from PySide6.QtCore import QSettings, Qt, QTimer
 
 from app.resources import icons_rc  # noqa: F401
 from app.ui.ui_main_window import Ui_MainWindow
-from app.data import db, export_service
+from app.data import db, export_service, summary_service
 from .notificaciones import notify_low_stock, notify_pending_repairs
 
 logger = logging.getLogger(__name__)
@@ -178,7 +178,7 @@ class MainWindow(QMainWindow):
         self.statusBar().showMessage("Panel actualizado", 2500)
 
     def refresh_summary(self):
-        total_clientes, total_dispositivos, total_productos, total_reparaciones = db.get_counts()
+        total_clientes, total_dispositivos, total_productos, total_reparaciones = summary_service.get_counts()
         self._set_label_text(["label_total_clientes", "labelTotalClientes"], total_clientes)
         self._set_label_text(["label_total_dispositivos", "labelTotalDispositivos"], total_dispositivos)
         self._set_label_text(["label_total_productos", "labelTotalProductos"], total_productos)

--- a/tests/test_summary_service.py
+++ b/tests/test_summary_service.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.data import summary_service
+
+
+def test_get_counts_returns_db_values(monkeypatch):
+    fake_db = SimpleNamespace(
+        contar_clientes=lambda: 1,
+        contar_dispositivos=lambda: 2,
+        contar_productos=lambda: 3,
+        contar_reparaciones_pendientes=lambda: 4,
+    )
+    monkeypatch.setattr(summary_service, "db", fake_db)
+
+    assert summary_service.get_counts() == (1, 2, 3, 4)
+
+
+def test_get_counts_handles_exceptions(monkeypatch):
+    def raise_exc():
+        raise RuntimeError("boom")
+
+    fake_db = SimpleNamespace(
+        contar_clientes=raise_exc,
+        contar_dispositivos=lambda: 2,
+        contar_productos=raise_exc,
+        contar_reparaciones_pendientes=lambda: 4,
+    )
+    monkeypatch.setattr(summary_service, "db", fake_db)
+
+    assert summary_service.get_counts() == (0, 2, 0, 4)


### PR DESCRIPTION
## Summary
- remove redundant `get_counts` from db layer
- route dashboard summaries through `summary_service.get_counts`
- add unit tests for summary service error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f08bd62a0832b92c2c1d0900820e4