### PR TITLE
feat: add calendar and technician workload

### DIFF
--- a/app/data/summary_service.py
+++ b/app/data/summary_service.py
@@ -1,7 +1,7 @@
 """Summary service for dashboard counts."""
 from __future__ import annotations
 
-from typing import cast
+from typing import cast, List, Tuple
 
 from app.data import db
 
@@ -27,3 +27,11 @@ def get_counts() -> tuple[int, int, int, int]:
             counts.append(0)
 
     return cast(tuple[int, int, int, int], tuple(counts))
+
+
+def get_workload_metrics() -> List[Tuple[str, int, int]]:
+    """Return workload metrics per technician."""
+    try:
+        return db.get_workload_metrics()
+    except Exception:
+        return []

--- a/app/views/calendar_dialog.py
+++ b/app/views/calendar_dialog.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QCalendarWidget, QListWidget
+from PySide6.QtCore import QDate
+
+from app.data import db
+
+
+class CalendarDialog(QDialog):
+    """Simple calendar view for scheduled repairs."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Calendario de tareas")
+        layout = QVBoxLayout(self)
+        self.calendar = QCalendarWidget(self)
+        self.tasks = QListWidget(self)
+        layout.addWidget(self.calendar)
+        layout.addWidget(self.tasks)
+        self.calendar.selectionChanged.connect(self._load_tasks)
+        self._load_tasks()
+
+    def _load_tasks(self) -> None:
+        date = self.calendar.selectedDate().toString("yyyy-MM-dd")
+        self.tasks.clear()
+        for _id, desc, tech in db.get_tasks_by_date(date):
+            if tech:
+                self.tasks.addItem(f"{desc} ({tech})")
+            else:
+                self.tasks.addItem(desc)

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -21,6 +21,7 @@ from app.resources import icons_rc  # noqa: F401
 from app.ui.ui_main_window import Ui_MainWindow
 from app.data import db, export_service, summary_service
 from .notificaciones import notify_low_stock, notify_pending_repairs
+from .calendar_dialog import CalendarDialog
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,8 @@ class MainWindow(QMainWindow):
         self.ui.actionInventario.triggered.connect(self._open_inventario)
         self.ui.actionReparaciones.triggered.connect(self._open_reparaciones)
         self.ui.actionActualizar.triggered.connect(self.refresh_all)
+        self.actionCalendario = self.ui.menuModulos.addAction("Calendario")
+        self.actionCalendario.triggered.connect(self._open_calendar)
 
         # Export actions
         self._export_menu = self.ui.menuArchivo.addMenu("Exportar")
@@ -147,6 +150,10 @@ class MainWindow(QMainWindow):
         dlg = dlg_cls(self)
         if dlg.exec() == QDialog.Accepted:
             self.refresh_all()
+
+    def _open_calendar(self):
+        dlg = CalendarDialog(self)
+        dlg.exec()
 
     def _export_table(self, table: str) -> None:
         file_path, selected_filter = QFileDialog.getSaveFileName(

--- a/app/views/notificaciones.py
+++ b/app/views/notificaciones.py
@@ -25,3 +25,12 @@ def notify_pending_repairs(parent: QWidget, count: int) -> None:
         "Reparaciones pendientes",
         f"Hay {count} reparaciones pendientes.",
     )
+
+
+def notify_new_assignment(parent: QWidget, technician: str, description: str) -> None:
+    """Inform about a new repair assigned to a technician."""
+    QMessageBox.information(
+        parent,
+        "Nuevo trabajo asignado",
+        f"Se ha asignado '{description}' a {technician}.",
+    )

--- a/app/views/reparaciones_dialog.py
+++ b/app/views/reparaciones_dialog.py
@@ -49,6 +49,11 @@ class ReparacionesDialog(BaseDialog):
         total = self.ui.doubleSpinBoxTotal.value()
         saldo = self.ui.doubleSpinBoxSaldo.value()
         tecnico = self.ui.lineEditTecnico.text().strip()
+        tiempo_widget = getattr(self.ui, "spinBoxTiempoEstimado", None)
+        if tiempo_widget is not None:
+            tiempo_estimado = tiempo_widget.value()
+        else:
+            tiempo_estimado = 0
         garantia = self.ui.spinBoxGarantia.value()
         pass_bloqueo = self.ui.lineEditPassBloqueo.text().strip()
         respaldo = self.ui.checkBoxRespaldo.isChecked()
@@ -89,11 +94,16 @@ class ReparacionesDialog(BaseDialog):
             estado,
             prioridad,
             tecnico,
+            tiempo_estimado,
             garantia,
             pass_bloqueo,
             respaldo,
             accesorios,
         )
+        if tecnico:
+            from .notificaciones import notify_new_assignment
+
+            notify_new_assignment(self, tecnico, descripcion)
         QMessageBox.information(self, "Reparación", "Reparación guardada correctamente.")
         self._show_status("Reparación guardada")
         self.accept()


### PR DESCRIPTION
## Summary
- add calendar dialog to browse repairs by date
- support assigning repairs to technicians with estimated time
- send in-app notifications for new assignments and expose workload metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f15081494832b96ef91d28d5971d5