### PR TITLE
Add client notification service and web portal

### DIFF
--- a/app/portal.py
+++ b/app/portal.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from flask import Flask, jsonify
+
+from app.data import db
+
+app = Flask(__name__)
+
+
+@app.route("/tickets/<int:ticket_id>")
+def ticket_status(ticket_id: int):
+    """Return timeline for a ticket for clients to consult progress."""
+    timeline = db.get_ticket_timeline(ticket_id)
+    return jsonify({"ticket_id": ticket_id, "timeline": timeline})
+
+
+@app.route("/tickets/<int:ticket_id>/documents")
+def ticket_documents(ticket_id: int):
+    """Placeholder for document list associated with a ticket."""
+    return jsonify({"ticket_id": ticket_id, "documents": []})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for external integrations."""

--- a/app/services/message_templates.json
+++ b/app/services/message_templates.json
@@ -1,0 +1,3 @@
+{
+  "ticket_update": "Hola $name, tu ticket #$ticket_id ahora está en estado '$status'."
+}

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import smtplib
+from email.message import EmailMessage
+from typing import Any, Dict
+
+import requests
+
+from .templates import render_template
+from app.data import db
+
+
+class NotificationService:
+    """Send messages through various channels and record them."""
+
+    def __init__(self, sms_url: str | None = None, sms_token: str | None = None):
+        self.sms_url = sms_url
+        self.sms_token = sms_token
+
+    def send_sms(self, to: str, template: str, context: Dict[str, Any]) -> None:
+        message = render_template(template, context)
+        if self.sms_url and self.sms_token:
+            requests.post(
+                self.sms_url,
+                json={"to": to, "message": message},
+                headers={"Authorization": f"Bearer {self.sms_token}"},
+                timeout=10,
+            )
+        db.log_notification(to, "sms", message)
+
+    def send_email(
+        self,
+        to: str,
+        subject_template: str,
+        body_template: str,
+        context: Dict[str, Any],
+        smtp_server: str = "localhost",
+        smtp_port: int = 25,
+    ) -> None:
+        subject = render_template(subject_template, context)
+        body = render_template(body_template, context)
+        msg = EmailMessage()
+        msg["To"] = to
+        msg["Subject"] = subject
+        msg.set_content(body)
+        with smtplib.SMTP(smtp_server, smtp_port) as server:
+            server.send_message(msg)
+        db.log_notification(to, "email", body)
+
+    def send_whatsapp(self, to: str, template: str, context: Dict[str, Any]) -> None:
+        message = render_template(template, context)
+        if self.sms_url and self.sms_token:
+            requests.post(
+                self.sms_url,
+                json={"to": to, "message": message, "channel": "whatsapp"},
+                headers={"Authorization": f"Bearer {self.sms_token}"},
+                timeout=10,
+            )
+        db.log_notification(to, "whatsapp", message)

--- a/app/services/templates.py
+++ b/app/services/templates.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from string import Template
+from typing import Dict
+
+TEMPLATES_FILE = Path(__file__).with_name("message_templates.json")
+
+
+def load_templates() -> Dict[str, str]:
+    if TEMPLATES_FILE.exists():
+        with open(TEMPLATES_FILE, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return {}
+
+
+def render_template(name: str, context: Dict[str, object]) -> str:
+    templates = load_templates()
+    template_str = templates.get(name, "")
+    return Template(template_str).safe_substitute(context)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 PySide6>=6.7
 openpyxl>=3.1.2
+Flask>=3.0.0
+requests>=2.31.0

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.data import db
+from app.services import templates, notifications
+
+
+def test_render_template_uses_context():
+    result = templates.render_template(
+        "ticket_update", {"name": "Ana", "ticket_id": 1, "status": "listo"}
+    )
+    assert "Ana" in result
+    assert "1" in result
+
+
+def test_log_notification_records_entry(tmp_path):
+    db.init_db(str(tmp_path / "test.db"))
+    db.log_notification("user", "sms", "hola")
+    cur = db._ensure_conn().cursor()
+    cur.execute(
+        "SELECT destinatario, canal, mensaje FROM notificaciones"
+    )
+    assert cur.fetchone() == ("user", "sms", "hola")
+    db.close_db()
+
+
+def test_notification_service_sms(monkeypatch, tmp_path):
+    db.init_db(str(tmp_path / "test.db"))
+
+    sent: dict[str, object] = {}
+
+    def fake_post(url, json, headers=None, timeout=10):
+        sent.update({"url": url, "json": json, "headers": headers})
+        class Resp:
+            status_code = 200
+        return Resp()
+
+    monkeypatch.setattr(notifications.requests, "post", fake_post)
+
+    service = notifications.NotificationService(
+        sms_url="http://api.example", sms_token="tkn"
+    )
+    service.send_sms(
+        "123", "ticket_update", {"name": "Ana", "ticket_id": 5, "status": "proceso"}
+    )
+
+    cur = db._ensure_conn().cursor()
+    cur.execute("SELECT canal, mensaje FROM notificaciones")
+    canal, mensaje = cur.fetchone()
+    assert canal == "sms"
+    assert "Ana" in mensaje
+    assert sent["json"]["to"] == "123"
+    db.close_db()


### PR DESCRIPTION
## Summary
- add database table and helpers to log notification events
- introduce customizable templates and service for SMS, email and WhatsApp
- add simple Flask portal for clients to check ticket progress
- record each notification with timestamp and test notification flow

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f17a8fcbc832ba0e6e1dfffd766f7