### PR TITLE
Add productivity dashboard and automated reporting

### DIFF
--- a/app/data/summary_service.py
+++ b/app/data/summary_service.py
@@ -35,3 +35,19 @@ def get_workload_metrics() -> List[Tuple[str, int, int]]:
         return db.get_workload_metrics()
     except Exception:
         return []
+
+
+def get_productivity_metrics() -> List[Tuple[str, int, int, float]]:
+    """Return productivity metrics per technician."""
+    try:
+        return db.get_productivity_metrics()
+    except Exception:
+        return []
+
+
+def get_financial_summary() -> List[Tuple[str, float, float, float]]:
+    """Return monthly financial summary."""
+    try:
+        return db.get_financial_summary()
+    except Exception:
+        return []

--- a/app/services/report_service.py
+++ b/app/services/report_service.py
@@ -1,0 +1,113 @@
+"""Service functions for generating and exporting reports."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Iterable, List, Tuple
+import threading
+
+from openpyxl import Workbook
+
+try:  # pragma: no cover - optional dependency checked at runtime
+    from reportlab.lib.pagesizes import letter
+    from reportlab.pdfgen import canvas
+except Exception:  # pragma: no cover
+    canvas = None  # type: ignore
+
+import matplotlib
+matplotlib.use("Agg")  # Use non-GUI backend for tests
+import matplotlib.pyplot as plt
+
+from app.data import summary_service
+
+FinancialRow = Tuple[str, float, float, float]
+
+
+def create_financial_chart(data: Iterable[FinancialRow], filepath: str) -> None:
+    """Generate a line chart of ingresos, costos and margen."""
+    periods = [row[0] for row in data]
+    incomes = [row[1] for row in data]
+    costs = [row[2] for row in data]
+    margins = [row[3] for row in data]
+
+    plt.figure()
+    plt.plot(periods, incomes, label="Ingresos")
+    plt.plot(periods, costs, label="Costos")
+    plt.plot(periods, margins, label="Margen")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(filepath)
+    plt.close()
+
+
+def export_report_to_excel(data: Iterable[FinancialRow], filepath: str) -> None:
+    """Export financial summary to an Excel file."""
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Periodo", "Ingresos", "Costos", "Margen"])
+    for row in data:
+        ws.append(list(row))
+    wb.save(filepath)
+
+
+def export_report_to_pdf(data: Iterable[FinancialRow], filepath: str) -> None:
+    """Export financial summary to a simple PDF file."""
+    if canvas is None:  # pragma: no cover - depends on optional lib
+        raise RuntimeError("reportlab is required for PDF export")
+    c = canvas.Canvas(filepath, pagesize=letter)
+    text = c.beginText(40, 750)
+    text.textLine("Reporte financiero")
+    for period, ingreso, costo, margen in data:
+        text.textLine(f"{period}: {ingreso:.2f} / {costo:.2f} / {margen:.2f}")
+    c.drawText(text)
+    c.showPage()
+    c.save()
+
+
+def generate_full_report(output_dir: str) -> List[FinancialRow]:
+    """Generate financial summary and export to PDF and Excel."""
+    data = summary_service.get_financial_summary()
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    export_report_to_excel(data, str(out / "reporte.xlsx"))
+    try:  # PDF is optional
+        export_report_to_pdf(data, str(out / "reporte.pdf"))
+    except Exception:
+        pass
+    chart_path = out / "reporte.png"
+    create_financial_chart(data, str(chart_path))
+    return data
+
+
+def schedule_periodic_report(
+    interval_seconds: int,
+    output_dir: str,
+    *,
+    task: Callable[[str], List[FinancialRow]] = generate_full_report,
+) -> "_RepeatingTimer":
+    """Schedule periodic generation of financial reports."""
+
+    class _RepeatingTimer:
+        def __init__(self) -> None:
+            self._stopped = False
+            self._timer: threading.Timer | None = None
+
+        def _run(self) -> None:
+            if self._stopped:
+                return
+            task(output_dir)
+            self._timer = threading.Timer(interval_seconds, self._run)
+            self._timer.daemon = True
+            self._timer.start()
+
+        def start(self) -> "_RepeatingTimer":
+            self._timer = threading.Timer(interval_seconds, self._run)
+            self._timer.daemon = True
+            self._timer.start()
+            return self
+
+        def cancel(self) -> None:
+            self._stopped = True
+            if self._timer:
+                self._timer.cancel()
+
+    return _RepeatingTimer().start()

--- a/app/views/dashboard_dialog.py
+++ b/app/views/dashboard_dialog.py
@@ -1,0 +1,85 @@
+"""Dialog displaying productivity indicators and financial charts."""
+from __future__ import annotations
+
+import tempfile
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QFileDialog,
+)
+
+from app.data import summary_service
+from app.services import report_service
+
+
+class DashboardDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Panel de productividad")
+        layout = QVBoxLayout(self)
+
+        self.table = QTableWidget(self)
+        layout.addWidget(self.table)
+
+        self.chart_label = QLabel(self)
+        self.chart_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.chart_label)
+
+        btn_layout = QHBoxLayout()
+        self.btn_pdf = QPushButton("Exportar PDF")
+        self.btn_excel = QPushButton("Exportar Excel")
+        btn_layout.addWidget(self.btn_pdf)
+        btn_layout.addWidget(self.btn_excel)
+        layout.addLayout(btn_layout)
+
+        self.btn_pdf.clicked.connect(self._export_pdf)
+        self.btn_excel.clicked.connect(self._export_excel)
+
+        self.refresh()
+
+    def refresh(self) -> None:
+        data = summary_service.get_productivity_metrics()
+        self.table.setRowCount(len(data))
+        self.table.setColumnCount(4)
+        self.table.setHorizontalHeaderLabels([
+            "Técnico",
+            "Completadas",
+            "Pendientes",
+            "Tiempo prom. (h)",
+        ])
+        for row, (tec, comp, pend, avg) in enumerate(data):
+            self.table.setItem(row, 0, QTableWidgetItem(tec))
+            self.table.setItem(row, 1, QTableWidgetItem(str(comp)))
+            self.table.setItem(row, 2, QTableWidgetItem(str(pend)))
+            self.table.setItem(row, 3, QTableWidgetItem(f"{avg:.1f}"))
+        self.table.resizeColumnsToContents()
+
+        fin_data = summary_service.get_financial_summary()
+        if fin_data:
+            tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+            tmp.close()
+            report_service.create_financial_chart(fin_data, tmp.name)
+            self.chart_label.setPixmap(QPixmap(tmp.name))
+            self._last_chart = tmp.name
+        else:
+            self.chart_label.setText("Sin datos financieros")
+            self._last_chart = None
+
+    def _export_pdf(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(self, "Guardar PDF", "reporte.pdf", "PDF (*.pdf)")
+        if path:
+            data = summary_service.get_financial_summary()
+            report_service.export_report_to_pdf(data, path)
+
+    def _export_excel(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(self, "Guardar Excel", "reporte.xlsx", "Excel (*.xlsx)")
+        if path:
+            data = summary_service.get_financial_summary()
+            report_service.export_report_to_excel(data, path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ PySide6>=6.7
 openpyxl>=3.1.2
 Flask>=3.0.0
 requests>=2.31.0
+matplotlib>=3.7.1
+reportlab>=4.0.9

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,125 @@
+import os
+import sys
+import time
+from datetime import datetime
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.data import db, summary_service
+from app.services import report_service
+
+
+def setup_sample_db(tmp_path):
+    db.init_db(str(tmp_path / "test.db"))
+    # Completed repair for tech1
+    r1 = db.add_repair(
+        cliente_nombre="Juan",
+        marca="Marca",
+        modelo="Modelo",
+        descripcion="",
+        diagnostico="",
+        acciones="",
+        piezas_usadas="",
+        costo_mano_obra=20.0,
+        costo_piezas=30.0,
+        deposito_pagado=0.0,
+        total=100.0,
+        saldo=0.0,
+        estado="Completada",
+        prioridad="Normal",
+        tecnico="tech1",
+        tiempo_estimado=2,
+        garantia_dias=0,
+        pass_bloqueo="",
+        respaldo_datos=False,
+        accesorios_entregados="",
+    )
+    # Pending repair for tech1
+    db.add_repair(
+        cliente_nombre="Juan",
+        marca="Marca",
+        modelo="Modelo",
+        descripcion="",
+        diagnostico="",
+        acciones="",
+        piezas_usadas="",
+        costo_mano_obra=5.0,
+        costo_piezas=10.0,
+        deposito_pagado=0.0,
+        total=0.0,
+        saldo=0.0,
+        estado="Pendiente",
+        prioridad="Normal",
+        tecnico="tech1",
+        tiempo_estimado=1,
+        garantia_dias=0,
+        pass_bloqueo="",
+        respaldo_datos=False,
+        accesorios_entregados="",
+    )
+    # Pending repair for tech2
+    db.add_repair(
+        cliente_nombre="Juan",
+        marca="Marca",
+        modelo="Modelo",
+        descripcion="",
+        diagnostico="",
+        acciones="",
+        piezas_usadas="",
+        costo_mano_obra=0.0,
+        costo_piezas=0.0,
+        deposito_pagado=0.0,
+        total=0.0,
+        saldo=0.0,
+        estado="Pendiente",
+        prioridad="Normal",
+        tecnico="tech2",
+        tiempo_estimado=3,
+        garantia_dias=0,
+        pass_bloqueo="",
+        respaldo_datos=False,
+        accesorios_entregados="",
+    )
+    cid = db.listar_clientes()[0][0]
+    factura_id = db.crear_factura(r1, cid, 100.0)
+    return factura_id
+
+
+def test_productivity_and_financial_summary(tmp_path):
+    setup_sample_db(tmp_path)
+    prod = summary_service.get_productivity_metrics()
+    prod_dict = {row[0]: row[1:] for row in prod}
+    assert prod_dict["tech1"] == (1, 1, pytest.approx(1.5))
+    assert prod_dict["tech2"] == (0, 1, pytest.approx(3.0))
+
+    period = datetime.now().strftime("%Y-%m")
+    fin = summary_service.get_financial_summary()
+    assert fin == [(period, 100.0, 65.0, 35.0)]
+
+
+def test_report_service_exports(tmp_path):
+    setup_sample_db(tmp_path)
+    data = summary_service.get_financial_summary()
+    chart_path = tmp_path / "chart.png"
+    report_service.create_financial_chart(data, str(chart_path))
+    assert chart_path.exists() and chart_path.stat().st_size > 0
+
+    excel_path = tmp_path / "report.xlsx"
+    report_service.export_report_to_excel(data, str(excel_path))
+    assert excel_path.exists() and excel_path.stat().st_size > 0
+
+    pdf_path = tmp_path / "report.pdf"
+    report_service.export_report_to_pdf(data, str(pdf_path))
+    assert pdf_path.exists() and pdf_path.stat().st_size > 0
+
+
+def test_schedule_periodic_report(tmp_path):
+    out_dir = tmp_path / "sched"
+    setup_sample_db(tmp_path)
+    timer = report_service.schedule_periodic_report(0.1, str(out_dir))
+    time.sleep(0.25)
+    timer.cancel()
+    # Expect at least one file created
+    assert any(out_dir.iterdir())


### PR DESCRIPTION
## Summary
- add database queries for technician productivity and monthly financial summaries
- introduce reporting service to chart finances, export PDF/Excel and schedule periodic generation
- create dashboard dialog and integrate report scheduling in main window
- include new tests for productivity metrics, exports and scheduler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f1e8ca6a4832b8a05a272ee1d9a6c