### PR TITLE
Add authentication roles, audit logging, and password recovery

### DIFF
--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Simple authentication and session management utilities."""
+
+from dataclasses import dataclass
+from typing import Optional, Set
+
+from app.data import db
+
+# Role definitions
+ADMIN = "admin"
+TECNICO = "tecnico"
+RECEPCIONISTA = "recepcionista"
+
+# Permissions per role
+ROLE_PERMISSIONS: dict[str, Set[str]] = {
+    ADMIN: {"view", "edit", "delete", "create"},
+    TECNICO: {"view", "edit", "create"},
+    RECEPCIONISTA: {"view", "create"},
+}
+
+
+@dataclass
+class UserSession:
+    id: int
+    nombre: str
+    rol: str
+
+
+class AuthService:
+    """Manage the authenticated user session and permissions."""
+
+    def __init__(self) -> None:
+        self._session: Optional[UserSession] = None
+
+    # Authentication
+    def login(self, nombre: str, password: str) -> bool:
+        user = db.get_usuario(nombre)
+        if user is None:
+            return False
+        user_id, password_hash, salt, rol = user
+        if not db.verify_password(password, password_hash, salt):
+            return False
+        self._session = UserSession(user_id, nombre, rol)
+        return True
+
+    def logout(self) -> None:
+        self._session = None
+
+    # Session info
+    @property
+    def current_user(self) -> Optional[UserSession]:
+        return self._session
+
+    # Permissions
+    def has_permission(self, perm: str) -> bool:
+        if self._session is None:
+            return False
+        return perm in ROLE_PERMISSIONS.get(self._session.rol, set())
+
+    def require_role(self, roles: Set[str]) -> None:
+        if self._session is None or self._session.rol not in roles:
+            raise PermissionError("Insufficient permissions")
+
+
+auth_service = AuthService()
+

--- a/app/views/login_dialog.py
+++ b/app/views/login_dialog.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import QKeySequence, QShortcut
 
-from app.data import db
+from app.services.auth import auth_service
 
 
 class LoginDialog(QDialog):
@@ -57,13 +57,8 @@ class LoginDialog(QDialog):
         if not nombre or not password:
             QMessageBox.warning(self, "Login", "Ingrese usuario y contraseña.")
             return
-        user = db.get_usuario(nombre)
-        if user is None:
-            QMessageBox.warning(self, "Login", "Usuario no encontrado.")
+        if not auth_service.login(nombre, password):
+            QMessageBox.warning(self, "Login", "Usuario o contraseña incorrectos.")
             return
-        _, password_hash, salt, rol = user
-        if not db.verify_password(password, password_hash, salt):
-            QMessageBox.warning(self, "Login", "Contraseña incorrecta.")
-            return
-        self.user_role = rol
+        self.user_role = auth_service.current_user.rol if auth_service.current_user else None
         self.accept()

--- a/tests/test_auth_audit.py
+++ b/tests/test_auth_audit.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.data import db
+from app.services.auth import AuthService
+
+
+def setup_db(tmp_path):
+    db.init_db(str(tmp_path / "auth.db"))
+
+
+def test_auth_service_and_roles(tmp_path):
+    setup_db(tmp_path)
+    service = AuthService()
+    assert service.login("admin", "admin")
+    assert service.has_permission("delete")
+    service.logout()
+    assert service.current_user is None
+
+
+def test_password_reset(tmp_path):
+    setup_db(tmp_path)
+    db.add_usuario("user", "Password9", "recepcionista")
+    token = db.create_password_reset("user")
+    assert db.reset_password(token, "Another9")
+    user = db.get_usuario("user")
+    assert user is not None
+    _, password_hash, salt, _ = user
+    assert db.verify_password("Another9", password_hash, salt)
+
+
+def test_audit_log(tmp_path):
+    setup_db(tmp_path)
+    db.add_usuario("tech", "TechPass9", "tecnico")
+    db.log_audit("tech", "delete", "clientes", 1)
+    logs = db.get_audit_logs("tech")
+    assert len(logs) == 1
+    assert logs[0][1] == "tech"


### PR DESCRIPTION
## Summary
- Implement session-based authentication service with role permissions
- Add audit logging and password reset utilities to database layer
- Integrate auth service in login dialog and add unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f1fecfc3c832bba32bf470d9ac68b