### PR TITLE
Add branch support with transfers and scoped configuration

### DIFF
--- a/app/data/export_service.py
+++ b/app/data/export_service.py
@@ -64,7 +64,7 @@ def import_table_from_csv(table: str, filepath: str) -> None:
     with open(filepath, newline="", encoding="utf-8") as fh:
         reader = csv.reader(fh)
         headers = next(reader)
-        rows = [row for row in reader]
+        rows = [[None if val == "" else val for val in row] for row in reader]
     conn = db._ensure_conn()
     cur = conn.cursor()
     cur.execute(f"DELETE FROM {table}")

--- a/app/data/summary_service.py
+++ b/app/data/summary_service.py
@@ -6,7 +6,7 @@ from typing import cast, List, Tuple
 from app.data import db
 
 
-def get_counts() -> tuple[int, int, int, int]:
+def get_counts(sucursal_id: int | None = None) -> tuple[int, int, int, int]:
     """Return counts of clients, devices, products and pending repairs.
 
     Returns:
@@ -22,32 +22,36 @@ def get_counts() -> tuple[int, int, int, int]:
     )
     for func in funcs:
         try:
-            counts.append(func())
+            import inspect
+            if "sucursal_id" in inspect.signature(func).parameters:
+                counts.append(func(sucursal_id))
+            else:
+                counts.append(func())
         except Exception:
             counts.append(0)
 
     return cast(tuple[int, int, int, int], tuple(counts))
 
 
-def get_workload_metrics() -> List[Tuple[str, int, int]]:
+def get_workload_metrics(sucursal_id: int | None = None) -> List[Tuple[str, int, int]]:
     """Return workload metrics per technician."""
     try:
-        return db.get_workload_metrics()
+        return db.get_workload_metrics(sucursal_id)
     except Exception:
         return []
 
 
-def get_productivity_metrics() -> List[Tuple[str, int, int, float]]:
+def get_productivity_metrics(sucursal_id: int | None = None) -> List[Tuple[str, int, int, float]]:
     """Return productivity metrics per technician."""
     try:
-        return db.get_productivity_metrics()
+        return db.get_productivity_metrics(sucursal_id)
     except Exception:
         return []
 
 
-def get_financial_summary() -> List[Tuple[str, float, float, float]]:
+def get_financial_summary(sucursal_id: int | None = None) -> List[Tuple[str, float, float, float]]:
     """Return monthly financial summary."""
     try:
-        return db.get_financial_summary()
+        return db.get_financial_summary(sucursal_id)
     except Exception:
         return []

--- a/app/services/report_service.py
+++ b/app/services/report_service.py
@@ -63,9 +63,9 @@ def export_report_to_pdf(data: Iterable[FinancialRow], filepath: str) -> None:
     c.save()
 
 
-def generate_full_report(output_dir: str) -> List[FinancialRow]:
+def generate_full_report(output_dir: str, sucursal_id: int | None = None) -> List[FinancialRow]:
     """Generate financial summary and export to PDF and Excel."""
-    data = summary_service.get_financial_summary()
+    data = summary_service.get_financial_summary(sucursal_id)
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
     export_report_to_excel(data, str(out / "reporte.xlsx"))
@@ -82,7 +82,8 @@ def schedule_periodic_report(
     interval_seconds: int,
     output_dir: str,
     *,
-    task: Callable[[str], List[FinancialRow]] = generate_full_report,
+    sucursal_id: int | None = None,
+    task: Callable[[str, int | None], List[FinancialRow]] = generate_full_report,
 ) -> "_RepeatingTimer":
     """Schedule periodic generation of financial reports."""
 
@@ -94,7 +95,7 @@ def schedule_periodic_report(
         def _run(self) -> None:
             if self._stopped:
                 return
-            task(output_dir)
+            task(output_dir, sucursal_id)
             self._timer = threading.Timer(interval_seconds, self._run)
             self._timer.daemon = True
             self._timer.start()

--- a/tests/test_sucursales.py
+++ b/tests/test_sucursales.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.data import db, summary_service
+
+
+@pytest.fixture(autouse=True)
+def setup_db(tmp_path):
+    path = tmp_path / "test.db"
+    db.init_db(str(path))
+    yield
+    db.close_db()
+
+
+def test_transfer_repuesto_between_sucursales():
+    s1 = db.add_sucursal("Centro")
+    s2 = db.add_sucursal("Norte")
+    db.add_repuesto("Pantalla", 5, "ACME", 10.0, sucursal_id=s1)
+    assert db.transfer_repuesto("Pantalla", s1, s2, 3) is True
+    cur = db._ensure_conn().cursor()
+    cur.execute("SELECT stock FROM repuestos WHERE nombre = 'Pantalla' AND sucursal_id = ?", (s1,))
+    assert cur.fetchone()[0] == 2
+    cur.execute("SELECT stock FROM repuestos WHERE nombre = 'Pantalla' AND sucursal_id = ?", (s2,))
+    assert cur.fetchone()[0] == 3
+
+
+def test_summary_filtered_by_sucursal():
+    s1 = db.add_sucursal("Centro")
+    s2 = db.add_sucursal("Norte")
+    db.add_product("Prod", 10, sucursal_id=s1)
+    db.add_product("Prod", 5, sucursal_id=s2)
+    cid = db.add_client("Juan")
+    did = db.add_device(cid, "M", "X")
+    conn = db._ensure_conn()
+    cur = conn.cursor()
+    cur.execute("INSERT INTO reparaciones (dispositivo_id, estado, sucursal_id) VALUES (?, 'Pendiente', ?)", (did, s1))
+    cur.execute("INSERT INTO reparaciones (dispositivo_id, estado, sucursal_id) VALUES (?, 'Pendiente', ?)", (did, s2))
+    conn.commit()
+    c1 = summary_service.get_counts(sucursal_id=s1)
+    c2 = summary_service.get_counts(sucursal_id=s2)
+    assert c1[2:] == (1, 1)
+    assert c2[2:] == (1, 1)
+
+
+def test_config_scope():
+    s1 = db.add_sucursal("Centro")
+    db.set_config("moneda", "USD")
+    db.set_config("moneda", "EUR", s1)
+    assert db.get_config("moneda", s1) == "EUR"
+    assert db.get_config("moneda") == "USD"
+    # Unknown branch falls back to global
+    assert db.get_config("moneda", 9999) == "USD"


### PR DESCRIPTION
## Summary
- add `sucursales` table and link branches to inventory, repairs, users and invoices
- allow transferring parts and repairs between branches and manage branch-specific config
- enable branch filtering for metrics and reports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f213adfac832ba2b5f3a352a56d6f