### PR TITLE
Add payment gateway with warranty and return APIs

### DIFF
--- a/app/portal.py
+++ b/app/portal.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 
 from app.data import db
+from app.services.payment import PaymentGateway, PaymentService
+from app.services.warranty import WarrantyService
+from app.services.returns import ReturnService
 
 app = Flask(__name__)
+
+gateway = PaymentGateway("https://api.example.com", "test")
+payment_service = PaymentService(gateway)
+warranty_service = WarrantyService()
+return_service = ReturnService()
 
 
 @app.route("/tickets/<int:ticket_id>")
@@ -18,6 +26,43 @@ def ticket_status(ticket_id: int):
 def ticket_documents(ticket_id: int):
     """Placeholder for document list associated with a ticket."""
     return jsonify({"ticket_id": ticket_id, "documents": []})
+
+
+@app.post("/api/payments")
+def api_payments():
+    data = request.get_json() or {}
+    factura_id = data.get("factura_id")
+    monto = data.get("monto")
+    result = payment_service.process_payment(factura_id, monto)
+    return jsonify(result)
+
+
+@app.post("/api/warranties")
+def api_warranties():
+    data = request.get_json() or {}
+    reparacion_id = data.get("reparacion_id")
+    descripcion = data.get("descripcion", "")
+    wid = warranty_service.register(reparacion_id, descripcion)
+    return jsonify({"garantia_id": wid})
+
+
+@app.get("/api/warranties")
+def list_warranties():
+    return jsonify({"garantias": warranty_service.list()})
+
+
+@app.post("/api/returns")
+def api_returns():
+    data = request.get_json() or {}
+    factura_id = data.get("factura_id")
+    motivo = data.get("motivo", "")
+    rid = return_service.register(factura_id, motivo)
+    return jsonify({"devolucion_id": rid})
+
+
+@app.get("/api/returns")
+def list_returns():
+    return jsonify({"devoluciones": return_service.list()})
 
 
 if __name__ == "__main__":

--- a/app/services/payment.py
+++ b/app/services/payment.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from app.data import db
+
+
+@dataclass
+class PaymentGateway:
+    """Simple HTTP-based payment gateway client."""
+
+    base_url: str
+    api_key: str
+
+    def charge(self, invoice_id: int, amount: float) -> dict[str, Any]:
+        """Charge an invoice through the remote gateway.
+
+        Raises ``HTTPError`` if the request fails.
+        """
+        response = requests.post(
+            f"{self.base_url.rstrip('/')}/charge",
+            json={"invoice_id": invoice_id, "amount": amount},
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+class PaymentService:
+    """Process payments using a payment gateway and record them in the DB."""
+
+    def __init__(self, gateway: PaymentGateway):
+        self.gateway = gateway
+
+    def process_payment(self, factura_id: int, amount: float) -> dict[str, Any]:
+        """Charge the amount and record the payment if successful."""
+        data = self.gateway.charge(factura_id, amount)
+        if data.get("status") != "succeeded":
+            raise RuntimeError("Payment failed")
+        db.registrar_pago(factura_id, amount)
+        return data

--- a/app/services/returns.py
+++ b/app/services/returns.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from app.data import db
+
+
+class ReturnService:
+    """Service to register and query product returns."""
+
+    def register(self, factura_id: int, motivo: str) -> int:
+        return db.registrar_devolucion(factura_id, motivo)
+
+    def list(self) -> List[Tuple[int, int, str, str, str]]:
+        return db.listar_devoluciones()

--- a/app/services/warranty.py
+++ b/app/services/warranty.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from app.data import db
+
+
+class WarrantyService:
+    """Service to register and query warranty claims."""
+
+    def register(self, reparacion_id: int, descripcion: str) -> int:
+        return db.registrar_garantia(reparacion_id, descripcion)
+
+    def list(self) -> List[Tuple[int, int, str, str, str]]:
+        return db.listar_garantias()

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,54 @@
+# API de Integración
+
+La aplicación expone una API HTTP basada en Flask para integrarse con
+plataformas externas como sistemas de e-commerce o CRM.
+
+## Autenticación
+
+Los ejemplos asumen que se utiliza una pasarela de pago externa que requiere
+un `api_key` configurado en el servidor.
+
+## Endpoints
+
+### `POST /api/payments`
+Realiza un cobro para una factura y registra el pago.
+
+```json
+{
+  "factura_id": 1,
+  "monto": 100.0
+}
+```
+
+### `POST /api/warranties`
+Registra una reclamación de garantía para una reparación.
+
+```json
+{
+  "reparacion_id": 1,
+  "descripcion": "Falla de pantalla"
+}
+```
+
+### `GET /api/warranties`
+Lista todas las garantías registradas.
+
+### `POST /api/returns`
+Registra una devolución asociada a una factura.
+
+```json
+{
+  "factura_id": 1,
+  "motivo": "Producto defectuoso"
+}
+```
+
+### `GET /api/returns`
+Lista las devoluciones registradas.
+
+## Flujos de integración
+1. El sistema externo crea una reparación y factura.
+2. Para cobrar en línea, envía los datos de la factura a `POST /api/payments`.
+3. Si el cliente presenta una falla cubierta por garantía, registra el evento en
+   `POST /api/warranties`.
+4. Para devoluciones de productos facturados, usar `POST /api/returns`.

--- a/tests/test_payment_service.py
+++ b/tests/test_payment_service.py
@@ -1,0 +1,59 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.data import db
+from app.services.payment import PaymentService, PaymentGateway
+
+
+class DummyGateway(PaymentGateway):
+    def __init__(self):
+        super().__init__("http://dummy", "key")
+        self.charges = []
+
+    def charge(self, invoice_id: int, amount: float):  # type: ignore[override]
+        self.charges.append((invoice_id, amount))
+        return {"status": "succeeded"}
+
+
+def _create_invoice() -> int:
+    repair_id = db.add_repair(
+        cliente_nombre="Juan",
+        marca="X",
+        modelo="Y",
+        descripcion="desc",
+        diagnostico="diag",
+        acciones="acc",
+        piezas_usadas="",
+        costo_mano_obra=10.0,
+        costo_piezas=5.0,
+        deposito_pagado=0.0,
+        total=15.0,
+        saldo=15.0,
+        estado="Pendiente",
+        prioridad="Normal",
+        tecnico="tech",
+        tiempo_estimado=2,
+        garantia_dias=0,
+        pass_bloqueo="",
+        respaldo_datos=False,
+        accesorios_entregados="",
+    )
+    cliente_id = db.listar_clientes()[0][0]
+    return db.crear_factura(repair_id, cliente_id, 15.0)
+
+
+def test_payment_service(tmp_path):
+    db.init_db(str(tmp_path / "test.db"))
+    factura_id = _create_invoice()
+
+    service = PaymentService(DummyGateway())
+    result = service.process_payment(factura_id, 15.0)
+
+    assert result["status"] == "succeeded"
+    total, pagado, saldo = db.obtener_estado_factura(factura_id)
+    assert total == 15.0
+    assert pagado == 15.0
+    assert saldo == 0.0
+    db.close_db()

--- a/tests/test_warranty_returns.py
+++ b/tests/test_warranty_returns.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.data import db
+
+
+def _create_repair_and_invoice():
+    repair_id = db.add_repair(
+        cliente_nombre="Ana",
+        marca="A",
+        modelo="B",
+        descripcion="desc",
+        diagnostico="diag",
+        acciones="acc",
+        piezas_usadas="",
+        costo_mano_obra=5.0,
+        costo_piezas=5.0,
+        deposito_pagado=0.0,
+        total=10.0,
+        saldo=10.0,
+        estado="Pendiente",
+        prioridad="Normal",
+        tecnico="tech",
+        tiempo_estimado=1,
+        garantia_dias=0,
+        pass_bloqueo="",
+        respaldo_datos=False,
+        accesorios_entregados="",
+    )
+    cliente_id = db.listar_clientes()[0][0]
+    factura_id = db.crear_factura(repair_id, cliente_id, 10.0)
+    return repair_id, factura_id
+
+
+def test_warranty_and_returns(tmp_path):
+    db.init_db(str(tmp_path / "test.db"))
+    reparacion_id, factura_id = _create_repair_and_invoice()
+
+    gid = db.registrar_garantia(reparacion_id, "fallo pantalla")
+    did = db.registrar_devolucion(factura_id, "defecto")
+
+    garantias = db.listar_garantias()
+    devoluciones = db.listar_devoluciones()
+
+    assert gid == garantias[0][0]
+    assert did == devoluciones[0][0]
+    assert garantias[0][2] == "fallo pantalla"
+    assert devoluciones[0][2] == "defecto"
+    db.close_db()


### PR DESCRIPTION
## Summary
- integrate HTTP payment gateway and record payments
- expose API endpoints for online payments, warranties and returns
- document integration endpoints and flows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f23835f94832b9f1ecde93cb34ba7