### PR TITLE
docs: document required system libraries for Qt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Proyecto base mínimo con estructura MVC para app de escritorio en Linux (PySide
 - Python 3.10+ recomendado
 - Linux (funciona también en macOS/Windows)
 - `pip install -r requirements.txt`
+- En algunas distribuciones minimalistas puede ser necesario instalar librerías de sistema adicionales:
+  `libgl1`, `libegl1` y `libxkbcommon0`
 
 ## Entorno
 ```bash


### PR DESCRIPTION
## Summary
- add note about installing libgl1, libegl1, and libxkbcommon0 on minimal distros

## Testing
- `pytest -q`
- `make doctor`


------
https://chatgpt.com/codex/tasks/task_e_689f26f1d318832b8c8cb6b8f7b2acea